### PR TITLE
Use correct react native packager `require` paths

### DIFF
--- a/lib/create-icon-set.js
+++ b/lib/create-icon-set.js
@@ -14,10 +14,10 @@ var {
   NativeModules,
 } = React;
 var RNVectorIconsManager = NativeModules.RNVectorIconsManager;
-var StyleSheetPropType = require('react-native/Libraries/StyleSheet/StyleSheetPropType');
-var flattenStyle = require('react-native/Libraries/StyleSheet/flattenStyle');
-var ViewStylePropTypes = require('react-native/Libraries/Components/View/ViewStylePropTypes');
-var TextStylePropTypes = require('react-native/Libraries/Text/TextStylePropTypes');
+var StyleSheetPropType = require('StyleSheetPropType');
+var flattenStyle = require('flattenStyle');
+var ViewStylePropTypes = require('ViewStylePropTypes');
+var TextStylePropTypes = require('TextStylePropTypes');
 
 var DEFAULT_ICON_SIZE = 12;
 var TAB_BAR_ICON_SIZE = 30;


### PR DESCRIPTION
This follows Facebook's internal pathing for their private modules - and allows other packagers (such as [react-native-webpack-server](https://github.com/mjohnston/react-native-webpack-server)) to properly resolve these guys.

See https://github.com/magus/react-native-facebook-login/pull/25 and https://github.com/mjohnston/react-native-webpack-server/issues/87 for some background