### PR TITLE
Allow passing of extra props to text element

### DIFF
--- a/lib/create-icon-set.js
+++ b/lib/create-icon-set.js
@@ -87,11 +87,11 @@ function createIconSet(glyphMap : Object, fontFamily : string, fontFile : string
           // FIXME: Temporary workaround until I can figure out how to automatically size icons
           textStyle.width = size;
         }
-        var textProps = this.props.textPropsAndroid || []
+        var textProps = this.props.textPropsAndroid || [];
         icon = (<TypefaceTextView style={textStyle} fontFile={fontFile} {...textProps}>{glyph}</TypefaceTextView>);
       } else {
         textStyle.fontFamily = fontFamily;
-        var textProps = this.props.textPropsIOS || []
+        var textProps = this.props.textPropsIOS || [];
         icon = (<Text style={textStyle} {...textProps}>{glyph}</Text>);
       }
 

--- a/lib/create-icon-set.js
+++ b/lib/create-icon-set.js
@@ -87,10 +87,12 @@ function createIconSet(glyphMap : Object, fontFamily : string, fontFile : string
           // FIXME: Temporary workaround until I can figure out how to automatically size icons
           textStyle.width = size;
         }
-        icon = (<TypefaceTextView style={textStyle} fontFile={fontFile}>{glyph}</TypefaceTextView>);
+        var textProps = this.props.textPropsAndroid
+        icon = (<TypefaceTextView style={textStyle} fontFile={fontFile} {...textProps}>{glyph}</TypefaceTextView>);
       } else {
         textStyle.fontFamily = fontFamily;
-        icon = (<Text style={textStyle}>{glyph}</Text>);
+        var textProps = this.props.textPropsIOS
+        icon = (<Text style={textStyle} {...textProps}>{glyph}</Text>);
       }
 
       return (

--- a/lib/create-icon-set.js
+++ b/lib/create-icon-set.js
@@ -87,11 +87,11 @@ function createIconSet(glyphMap : Object, fontFamily : string, fontFile : string
           // FIXME: Temporary workaround until I can figure out how to automatically size icons
           textStyle.width = size;
         }
-        var textProps = this.props.textPropsAndroid
+        var textProps = this.props.textPropsAndroid || []
         icon = (<TypefaceTextView style={textStyle} fontFile={fontFile} {...textProps}>{glyph}</TypefaceTextView>);
       } else {
         textStyle.fontFamily = fontFamily;
-        var textProps = this.props.textPropsIOS
+        var textProps = this.props.textPropsIOS || []
         icon = (<Text style={textStyle} {...textProps}>{glyph}</Text>);
       }
 


### PR DESCRIPTION
We're using vector icons for buttons, avatars, and widgets all over the place. I just realized that accessibility settings are causing misalignment if the text scaling is anything but the default. The fix is simple (`allowFontScaling={false}`), but I'm unable to apply it because props are passed only to the wrapper, not to the text element.

This PR addresses the issue by exposing `textPropsIOS` and `textPropsAndroid` that are passed directly to the text element. I didn't overthink this because it might not be the best way to accomplish this (allow injection of a text element of your choice maybe?), but it accomplishes what we need, affects nothing else, and could be useful.

For a similar issue, see: oblador/react-native-vector-icons#23

Note: We also need the commenting-out of lines 77&78, but that's a separate issue, perhaps.