### PR TITLE
add useNativeAndroidText option for createIconSet

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,24 +2,24 @@
 
 **Choose from 3000+ icons or use your own.**
 
-Perfect for buttons, logos and nav/tab bars. Easy to extend, style and integrate into your project. 
+Perfect for buttons, logos and nav/tab bars. Easy to extend, style and integrate into your project.
 
 ## Main advantages over `react-native-icons`
 
-* You can use your own custom icon sets. Supports SVG via [Fontello](http://fontello.com) or regular icon fonts. 
+* You can use your own custom icon sets. Supports SVG via [Fontello](http://fontello.com) or regular icon fonts.
 * You can use *native* `TabBarIOS`.
-* You can use icons inline with `Text` components as emojis or to create buttons. 
-* You can use the icon as an image if a native component requires it (such as `NavigatorIOS`). 
-* Most common use cases is JavaScript only and thus enables wider possibilities of styling (and is easier to integrate with your project). 
+* You can use icons inline with `Text` components as emojis or to create buttons.
+* You can use the icon as an image if a native component requires it (such as `NavigatorIOS`).
+* Most common use cases is JavaScript only and thus enables wider possibilities of styling (and is easier to integrate with your project).
 * No need to define `width` and `height` styles.
 * Presentational stuff like size and color can be defined in your stylesheet instead of via a property (if you want to).
 * Icons scale with accessibility settings (unless disabled).
 
 ## Bundled Icon Sets
 
-* [`Entypo`](http://entypo.com) by Daniel Bruce (**411** icons) 
-* [`EvilIcons`](http://evil-icons.io) by Alexander Madyankin & Roman Shamin (v1.7.8, **70** icons) 
-* [`FontAwesome`](http://fortawesome.github.io/Font-Awesome/icons/) by Dave Gandy (v4.4, **585** icons) 
+* [`Entypo`](http://entypo.com) by Daniel Bruce (**411** icons)
+* [`EvilIcons`](http://evil-icons.io) by Alexander Madyankin & Roman Shamin (v1.7.8, **70** icons)
+* [`FontAwesome`](http://fortawesome.github.io/Font-Awesome/icons/) by Dave Gandy (v4.4, **585** icons)
 * [`Foundation`](http://zurb.com/playground/foundation-icon-fonts-3) by ZURB, Inc. (v3.0, **283** icons)
 * [`Ionicons`](http://ionicons.com/) by Ben Sperry (v2.0.1, **733** icons)
 * [`MaterialIcons`](https://www.google.com/design/icons/) by Google, Inc. (v2.0, **796** icons)
@@ -30,13 +30,13 @@ Perfect for buttons, logos and nav/tab bars. Easy to extend, style and integrate
 
 `$ npm install react-native-vector-icons --save`
 
-### iOS 
+### iOS
 
 #### Option: Manually
 
 If you want to use any of the bundled icons, you need to add the icon fonts to your XCode project. Just follow these steps:
 
-* Right click on you project in XCode and select **Add files to "_NameOfYourProject_"**. 
+* Right click on you project in XCode and select **Add files to "_NameOfYourProject_"**.
 * Browse to `node_modules/react-native-vector-icons` and select the folder `Fonts` (or just the ones you want). **Make sure your app is checked under "Add to targets" and that "Create groups" is checked if you add the whole folder**.
 * Edit `Info.plist` and add a property called **Fonts provided by application** (if you haven't added one already) and type in the files you just added. It will look something like this:
 
@@ -54,13 +54,13 @@ Add the following to your `Podfile` and run `pod update`:
 pod 'RNVectorIcons', :path => 'node_modules/react-native-vector-icons'
 ```
 
-Edit `Info.plist` as described above. 
+Edit `Info.plist` as described above.
 
 ### Android
 
 *Note: Android support requires React Native 0.12 or later*
 
-* Copy the whole `Fonts` folder to `android/app/src/main/assets`. 
+* Copy the whole `Fonts` folder to `android/app/src/main/assets`.
 * Edit `android/settings.gradle` to look like this:
 
   ```
@@ -73,7 +73,7 @@ Edit `Info.plist` as described above.
   project(':react-native-vector-icons').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-vector-icons/android')
   ```
 
-* Edit `android/app/build.gradle` (note: **app** folder) to look like this: 
+* Edit `android/app/build.gradle` (note: **app** folder) to look like this:
 
   ```
   apply plugin: 'com.android.application'
@@ -137,13 +137,13 @@ Edit `Info.plist` as described above.
 ### Known issues on android
 
 * Size can only be passed as a property, not with a stylesheet
-* Icons have a fixed width causing some icons to be clipped or have whitespace. Adjust with `style={{width: xx}}` for now. 
+* Icons have a fixed width causing some icons to be clipped or have whitespace. Adjust with `style={{width: xx}}` for now.
 * Icons cannot be nested within a `Text` component.
 
 *Custom font support has been merged into React Native Master which will fix these problems, but has yet to make it into a public release.*
 
 ## `Icon` Component
-You can either use one of the bundled icons above or roll your own custom font. 
+You can either use one of the bundled icons above or roll your own custom font.
 
 ```js
 var Icon = require('react-native-vector-icons/FontAwesome');
@@ -151,7 +151,7 @@ var myIcon = (<Icon name="rocket" size={30} color="#900" />)
 ```
 
 ### Properties
-Any [Text property](http://facebook.github.io/react-native/docs/text.html) and the following: 
+Any [Text property](http://facebook.github.io/react-native/docs/text.html) and the following:
 
 | Prop | Description | Default |
 |---|---|---|
@@ -171,13 +171,13 @@ Since `Icon` builds on top of the `Text` component, most [style properties](htt
 * `color`
 * `fontSize`
 
-By combining some of these you can create for example: 
+By combining some of these you can create for example:
 
 ![type](https://cloud.githubusercontent.com/assets/378279/7667570/33817554-fc0d-11e4-9ad7-4eb60139cfb7.png)
 ![star](https://cloud.githubusercontent.com/assets/378279/7667569/3010dd7e-fc0d-11e4-9696-cb721fe8e98d.png)
 
 ## `Icon.Button` Component
-A convenience component for creating buttons with an icon on the left side. 
+A convenience component for creating buttons with an icon on the left side.
 
 ```js
 var Icon = require('react-native-vector-icons/FontAwesome')
@@ -220,7 +220,7 @@ For a complete example check out the `TabBarExample` project.
 
 ## Usage with [TabBarIOS](http://facebook.github.io/react-native/docs/tabbarios.html)
 
-Simply use `Icon.TabBarItem` instead of `TabBarIOS.Item`. This is an extended component that works exactly the same but with three additional properties: 
+Simply use `Icon.TabBarItem` instead of `TabBarIOS.Item`. This is an extended component that works exactly the same but with three additional properties:
 
 | Prop | Description | Default |
 |---|---|---|
@@ -228,13 +228,13 @@ Simply use `Icon.TabBarItem` instead of `TabBarIOS.Item`. This is an extended co
 |**`selectedIconName`**|Name of the selected icon (similar to `TabBarIOS.Item` `selectedIcon`). |*`iconName`*|
 |**`iconSize`**|Size of the icon. |`30`|
 
-For example usage see `Examples/TabBarExample` or the examples section below. Don't forget to import and link to this project as described above if you are going to use the TabBar integration. 
+For example usage see `Examples/TabBarExample` or the examples section below. Don't forget to import and link to this project as described above if you are going to use the TabBar integration.
 
 ## Usage with [NavigatorIOS](http://facebook.github.io/react-native/docs/navigatorios.html)
 
-Use `Icon.getImageSource` to get an image source object and pass it as you would with `backButtonIcon`, `leftButtonIcon` or `rightButtonIcon`. 
+Use `Icon.getImageSource` to get an image source object and pass it as you would with `backButtonIcon`, `leftButtonIcon` or `rightButtonIcon`.
 
-Note: Since [`NavigatorIOS` doesn't rerender with new state](https://github.com/facebook/react-native/issues/1403) and the async nature of `getImageSource` you must not use it with `initialRoute` until the icon is rendered, but any view added by `push` should be fine. Easiest way is to simple add an `if` statment at the beginning of you render method like this: 
+Note: Since [`NavigatorIOS` doesn't rerender with new state](https://github.com/facebook/react-native/issues/1403) and the async nature of `getImageSource` you must not use it with `initialRoute` until the icon is rendered, but any view added by `push` should be fine. Easiest way is to simple add an `if` statment at the beginning of you render method like this:
 
 ```
   render: function() {
@@ -245,15 +245,15 @@ Note: Since [`NavigatorIOS` doesn't rerender with new state](https://github.com/
   }
 ```
 
-[Facebook writes](http://facebook.github.io/react-native/docs/navigator-comparison.html#navigatorios): 
+[Facebook writes](http://facebook.github.io/react-native/docs/navigator-comparison.html#navigatorios):
 > Development belongs to open-source community - not used by the React Native team on their apps. A result of this is that there is currently a backlog of unresolved bugs, nobody who uses this has stepped up to take ownership for it yet.
 
 You are probably better off with [`Navigator.NavigationBar`](http://facebook.github.io/react-native/docs/navigator.html) or [`react-native-navbar`](https://github.com/Kureev/react-native-navbar).
 
 ## Custom Fonts
 
-### `createIconSet(glyphMap, fontFamily[, fontFile])`
-Returns your own custom font based on the `glyphMap` where the key is the icon name and the value is either a UTF-8 character or it's character code. `fontFamily` is the name of the font **NOT** the filename. Open the font in Font Book.app or similar to learn the name. Optionally pass the third `fontFile` argument for android support, it should be a path to the font file in you asset folder. 
+### `createIconSet(glyphMap, fontFamily[, fontFile[, useNativeAndroidText]])`
+Returns your own custom font based on the `glyphMap` where the key is the icon name and the value is either a UTF-8 character or it's character code. `fontFamily` is the name of the font **NOT** the filename. Open the font in Font Book.app or similar to learn the name. Optionally pass the third `fontFile` argument for android support, it should be a path to the font file in you asset folder.
 
 ```js
 var { createIconSet } = require('react-native-vector-icons');
@@ -261,8 +261,8 @@ var glyphMap = { 'icon-name': 1234, test: '∆' };
 var Icon = createIconSet(glyphMap, 'FontName');
 ```
 
-### `createIconSetFromFontello(config[, fontFamily[, fontFile]])`
-Convenience method to create a custom font based on a [fontello](http://fontello.com) config file. Don't forget to import the font as described above and drop the `config.json` somewhere convenient in your project. 
+### `createIconSetFromFontello(config[, fontFamily[, fontFile[, useNativeAndroidText]]])`
+Convenience method to create a custom font based on a [fontello](http://fontello.com) config file. Don't forget to import the font as described above and drop the `config.json` somewhere convenient in your project.
 
 ```js
 var { createIconSetFromFontello } = require('react-native-vector-icons');
@@ -273,7 +273,7 @@ var Icon = createIconSetFromFontello(fontelloConfig);
 ## Examples
 
 ### IconExplorer
-Try the `IconExplorer` project in `Examples/IconExplorer` folder, there you can also search for any icon. 
+Try the `IconExplorer` project in `Examples/IconExplorer` folder, there you can also search for any icon.
 
 ![Screenshot of IconExplorer](https://cloud.githubusercontent.com/assets/378279/8903470/a9fe6b46-3458-11e5-901f-98b7b676d0d3.png)
 
@@ -291,13 +291,13 @@ var ExampleView = React.createClass({
 ```
 
 ### TabBar
-Full example in `TabBarExample` project in `Examples/TabBarExample` folder. 
+Full example in `TabBarExample` project in `Examples/TabBarExample` folder.
 
 ```js
 var React = require('react-native');
 var {
-  View, 
-  Text, 
+  View,
+  Text,
   TabBarIOS,
 } = React;
 var Icon = require('react-native-vector-icons/Ionicons');
@@ -339,9 +339,9 @@ var ExampleView = React.createClass({
 
 ## Generating your own icon set from a CSS file
 
-If you already have a icon font with associated CSS file then you can easily generate a icon set with the `generate-icon` script. 
+If you already have a icon font with associated CSS file then you can easily generate a icon set with the `generate-icon` script.
 
-### Example usage: 
+### Example usage:
 
 ```
 ./node_modules/.bin/generate-icon path/to/styles.css --componentName=MyIcon --fontFamily=myicon > Components/MyIcon.js
@@ -349,7 +349,7 @@ If you already have a icon font with associated CSS file then you can easily gen
 
 ### Options
 
-Any flags not listed below, like `--componentName` and `--fontFamily`, will be passed on to the template. 
+Any flags not listed below, like `--componentName` and `--fontFamily`, will be passed on to the template.
 
 #### `-p`, `--prefix`
 CSS selector prefix [default: ".icon-"]

--- a/lib/create-icon-set-from-fontello.js
+++ b/lib/create-icon-set-from-fontello.js
@@ -6,7 +6,7 @@
 
 var createIconSet = require('./create-icon-set');
 
-function createIconSetFromFontello(config : Object, fontFamily? : string, fontFile? : string) : Function {
+function createIconSetFromFontello(config : Object, fontFamily? : string, fontFile? : string, useNativeAndroidText? : boolean) : Function {
   var glyphMap = {};
   config.glyphs.forEach(function (glyph) {
     glyphMap[glyph.css] = glyph.code;
@@ -14,7 +14,7 @@ function createIconSetFromFontello(config : Object, fontFamily? : string, fontFi
   fontFamily = fontFamily || config.name;
   fontFile = fontFile || 'Fonts/' + fontFamily + '.ttf';
 
-  return createIconSet(glyphMap, fontFamily, fontFile)
+  return createIconSet(glyphMap, fontFamily, fontFile, useNativeAndroidText)
 };
 
 module.exports = createIconSetFromFontello;

--- a/lib/create-icon-set.js
+++ b/lib/create-icon-set.js
@@ -39,7 +39,7 @@ if(Platform.OS === 'android') {
   TypefaceTextView = require('./TypefaceTextView');
 }
 
-function createIconSet(glyphMap : Object, fontFamily : string, fontFile : string) : Function {
+function createIconSet(glyphMap : Object, fontFamily : string, fontFile : string, useNativeAndroidText? : boolean) : Function {
   var Icon = React.createClass({
     propTypes: {
       name: React.PropTypes.oneOf(Object.keys(glyphMap)).isRequired,
@@ -75,7 +75,7 @@ function createIconSet(glyphMap : Object, fontFamily : string, fontFile : string
 
       // For android we have to use our own subclass of the TextView since it
       // doesn't yet support custom fonts
-      if(Platform.OS === 'android') {
+      if(Platform.OS === 'android' && useNativeAndroidText !== true) {
         // FIXME: Temporary workaround until I can figure out how to automatically size icons
         styleDefaults.width = size;
         styleDefaults.height = size;


### PR DESCRIPTION
I had problems with TypefaceTextView icon scaling on some Android devices so I applied https://github.com/facebook/react-native/commit/bfeaa6a4f531cfc18c097bc9ffb6a8dbe3ddc702 on top of `0.14-stable` branch and it worked fine. The only problem is that I had to fork the project so I could prevent `Icon` component form using `TypefaceTextView`.

This patch adds `useNativeAndroidText` option for `createIconSet` and `createIconSetFromFontello` that could be later removed and replaced with version check if you want to keep backwards compatibility with older react-native versions and continue to use `TypefaceTextView`.

It also appears that my editor removed trailing whitespaces from README file so please let me know if this is a problem and I will update pull request.