### PR TITLE
Support rnpm

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ Perfect for buttons, logos and nav/tab bars. Easy to extend, style and integrate
 
 `$ npm install react-native-vector-icons --save`
 
+if you're using rnpm, you can link all native dependencies automatically:
+
+`$ rnpm link`
+
 ### iOS 
 
 #### Option: Manually

--- a/package.json
+++ b/package.json
@@ -49,6 +49,9 @@
   "peerDependencies": {
     "react-native": ">=0.4.0 || 0.5.0-rc1 || 0.6.0-rc || 0.7.0-rc || 0.7.0-rc.2 || 0.8.0-rc || 0.8.0-rc.2 || 0.9.0-rc || 0.10.0-rc || 0.11.0-rc || 0.12.0-rc || 0.13.0-rc || 0.14.0-rc || 0.15.0-rc || 0.16.0-rc"
   },
+  "rnpm": {
+    "assets": ["Fonts"]
+  },
   "dependencies": {
     "lodash": "^3.8.0",
     "yargs": "^3.30.0"


### PR DESCRIPTION
Hi @oblador! 

I'd like to see your lib supporting `rnpm link`, so I've added `rnpm` config block to package.json file with only one option inside - assets. By adding `assets: ["Fonts"]` we're telling `rnpm` to copy react-native-vector-icons assets into project's assets folder. Also, I've updated README file to tell rnpm users that your lib can be linked automatically.

Let me know if you have any questions!