### PR TITLE
Migrate from peerDependencies to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,15 +46,13 @@
     "url": "git://github.com/oblador/react-native-vector-icons.git"
   },
   "license": "MIT",
-  "peerDependencies": {
-    "react-native": ">=0.4.0 || 0.5.0-rc1 || 0.6.0-rc || 0.7.0-rc || 0.7.0-rc.2 || 0.8.0-rc || 0.8.0-rc.2 || 0.9.0-rc || 0.10.0-rc || 0.11.0-rc || 0.12.0-rc || 0.13.0-rc || 0.14.0-rc || 0.15.0-rc || 0.16.0-rc"
-  },
   "rnpm": {
     "assets": ["Fonts"]
   },
   "dependencies": {
     "lodash": "^3.8.0",
-    "yargs": "^3.30.0"
+    "yargs": "^3.30.0",
+    "react-native": ">=0.4.0 || 0.5.0-rc1 || 0.6.0-rc || 0.7.0-rc || 0.7.0-rc.2 || 0.8.0-rc || 0.8.0-rc.2 || 0.9.0-rc || 0.10.0-rc || 0.11.0-rc || 0.12.0-rc || 0.13.0-rc || 0.14.0-rc || 0.15.0-rc || 0.16.0-rc"
   },
   "devDependencies": {
     "evil-icons": "^1.7.6",


### PR DESCRIPTION
With npm v3+ and it's flat dependencies structure there are no reasons to keep using peerDependencies any more.

Besides this, `peerDependency`'s errors are really annoying:
![image](https://cloud.githubusercontent.com/assets/2273613/11748366/2e4acc6a-a028-11e5-923f-a24a6d7c2b2f.png)
