### PR TITLE
Font mapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,36 @@ By combining some of these you can create for example:
 ![type](https://cloud.githubusercontent.com/assets/378279/7667570/33817554-fc0d-11e4-9ad7-4eb60139cfb7.png)
 ![star](https://cloud.githubusercontent.com/assets/378279/7667569/3010dd7e-fc0d-11e4-9696-cb721fe8e98d.png)
 
+
+## Font-mapper
+If you want to use same component for iOS & android (this is useful if you use single components for both platforms), it's possible to create a mapping between font-name and font-family depending on platform.
+
+```js
+let { FontMapper } = require('react-native-vector-icons')
+let AndroidFont = require('react-native-vector-icons/MaterialIcons')
+let iOSFont = require('react-native-vector-icons/EvilIcons')
+
+let androidToIOSMap = {
+  "arrow-back": "arrow-left",
+}
+
+let IconFont = React.createClass({
+  render() {
+    return (
+      <FontMapper
+        iOSFont={iOSFont}
+        androidFont={AndroidFont}
+        androidToIOSMap={androidToIOSMap} />
+    )
+  }
+})
+```
+
+After that, will be possible to use `<IconFont color='white' name="arrow-back" size={35} />` (master-name will be android in this case) and it will choose MaterialDesign or EvilIcons depending on platform.
+
+Note that you could also do the mapping on inverse way (from iOS -> android) usign `iOSToAndroidMap` prop.
+
+
 ## `Icon.Button` Component
 A convenience component for creating buttons with an icon on the left side. 
 

--- a/index.js
+++ b/index.js
@@ -2,8 +2,10 @@
 
 var createIconSet = require('./lib/create-icon-set');
 var createIconSetFromFontello = require('./lib/create-icon-set-from-fontello');
+var FontMapper = require('./lib/font-mapper');
 
 module.exports = {
   createIconSet,
   createIconSetFromFontello,
+  FontMapper
 };

--- a/lib/font-mapper.js
+++ b/lib/font-mapper.js
@@ -1,0 +1,61 @@
+/**
+* @providesModule FontMapper
+* @flow
+*/
+'use strict';
+
+let React = require('react-native');
+let {
+  Platform
+} = React
+
+
+let FontMapper = React.createClass({
+  propTypes: {
+    size: React.PropTypes.oneOfType([
+            React.PropTypes.number,
+            React.PropTypes.object
+          ]),
+    iOSFont: React.PropTypes.func,
+    androidFont: React.PropTypes.func,
+    iOSToAndroidMap: React.PropTypes.object,
+    androidToIOSMap: React.PropTypes.object,
+  },
+
+  getDefaultProps: function () {
+    return {
+      iOSToAndroidMap: {},
+      androidToIOSMap: {}
+    };
+  },
+
+  render() {
+    let PlatformFont
+    let {name, size, ...rest} = this.props
+
+    if (Platform.OS === 'android') {
+      PlatformFont = this.props.androidFont
+      name = this.props.iOSToAndroidMap[this.props.name] || name
+    } else if (Platform.OS === 'ios') {
+      PlatformFont =  this.props.iOSFont
+      name = this.props.androidToIOSMap[this.props.name] || name
+    }
+
+    if (typeof(size) == "object") {
+      if (Platform.OS === 'android') {
+        size = size.android || size
+      } else if (Platform.OS === 'ios') {
+        size= size.ios || size
+      }
+    }
+
+    return (
+      <PlatformFont
+        name={name}
+        size={size}
+        {...rest} />
+    )
+  }
+})
+
+module.exports = FontMapper;


### PR DESCRIPTION
Add convenience way to use same names on iOS than android, to allow simple-components (same component file for iOS & android).