### PR TITLE
Fix for TabBarIcon issue when receiving new props

### DIFF
--- a/lib/create-icon-set.js
+++ b/lib/create-icon-set.js
@@ -201,24 +201,24 @@ function createIconSet(glyphMap : Object, fontFamily : string, fontFile : string
       iconSize: React.PropTypes.number,
     },
 
-    updateIconSources: function() {
+    updateIconSources: function(props) {
       var size = this.props.iconSize || TAB_BAR_ICON_SIZE;
-      if(this.props.iconName) {
-        getImageSource(this.props.iconName, size).then(icon => this.setState({ icon }));
+      if(props.iconName) {
+        getImageSource(props.iconName, size).then(icon => this.setState({ icon }));
       }
-      if(this.props.selectedIconName) {
-        getImageSource(this.props.selectedIconName, size).then(selectedIcon => this.setState({ selectedIcon }));
+      if(props.selectedIconName) {
+        getImageSource(props.selectedIconName, size).then(selectedIcon => this.setState({ selectedIcon }));
       }
     },
 
     componentWillMount: function() {
-      this.updateIconSources();
+      this.updateIconSources(this.props);
     },
 
     componentWillReceiveProps: function(nextProps) {
       var keys = Object.keys(TabBarItem.propTypes);
       if(!isEqual(pick(nextProps, keys), pick(this.props, keys))) {
-        this.updateIconSources();
+        this.updateIconSources(nextProps);
       }
     },
 


### PR DESCRIPTION
My fix for issue #94. Making `updateIconSources()` take a `props` param, which is `this.props` in `componentWillMount()` and `nextProps` in `componentWillReceiveProps()`.