### PR TITLE
Fix require issue

### DIFF
--- a/lib/create-icon-set.js
+++ b/lib/create-icon-set.js
@@ -4,10 +4,10 @@
  */
 'use strict';
 
-var pick = require('lodash/pick');
-var omit = require('lodash/omit');
-var isString = require('lodash/isString');
-var isEqual = require('lodash/isEqual');
+var pick = require('lodash').pick;
+var omit = require('lodash').omit;
+var isString = require('lodash').isString;
+var isEqual = require('lodash').isEqual;
 
 var React = require('react-native');
 var {


### PR DESCRIPTION
I noticed after installing this package using npm3, it attempts to pull in dependencies from lodash using `require('lodash/{ func name }')`, however with this approach, it fails to find the dependency.

I get the following error without this fix:

```
Unable to resolve module ./_baseFlatten from projectName/node_modules/react-native-vector-icons/node_modules/lodash/pick.js: Invalid directory react-native-vector-icons/node_modules/lodash/_baseFlatten
``` 

If there is a way to resolve this without the above fix, please send it along.
Thanks!