### PR TITLE
BugFix: Can't find variable: TabBarItem

### DIFF
--- a/lib/create-icon-set.js
+++ b/lib/create-icon-set.js
@@ -221,7 +221,7 @@ function createIconSet(glyphMap : Object, fontFamily : string, fontFile : string
     },
 
     componentWillReceiveProps: function(nextProps) {
-      var keys = Object.keys(TabBarItem.propTypes);
+      var keys = Object.keys(Icon.TabBarItem.propTypes);
       if(!isEqual(pick(nextProps, keys), pick(this.props, keys))) {
         this.updateIconSources(nextProps);
       }


### PR DESCRIPTION
Use `Icon.TabBarItem` and found `Can't find variable: TabBarItem`