### PR TITLE
Add gradle script to copy fonts

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,24 @@ Edit `Info.plist` as described above.
 
 `$ rnpm link`
 
+#### Option: With Gradle
+
+Edit `android/app/build.gradle` and add the following:
+
+```gradle
+apply from: "../../node_modules/react-native-vector-icons/fonts.gradle"
+```
+
+To customize the files being copied, add the following instead:
+
+```gradle
+project.ext.vectoricons = [
+    iconFontNames: [ 'MaterialIcons.ttf', 'EvilIcons.ttf' ] // Name of the font files you want to copy
+]
+
+apply from: "../../node_modules/react-native-vector-icons/fonts.gradle"
+```
+
 #### Option: Manually
 
 * Copy the contents in the `Fonts` folder to `android/app/src/main/assets/fonts` (*note lowercase font folder*). 
@@ -142,7 +160,7 @@ Any [Text property](http://facebook.github.io/react-native/docs/text.html) and t
 |**`color`**|Color of the icon. |*Inherited*|
 
 ### Styling
-Since `Icon` builds on top of the `Text` component, most [style properties](http://facebook.github.io/react-native/docs/style.html) will work as expected, you might find it useful to play around with these:
+Since `Icon` builds on top of the `Text` component, most [style properties](http://facebook.github.io/react-native/docs/style.html) will work as expected, you might find it useful to play around with these:
 
 * `backgroundColor`
 * `borderWidth`
@@ -426,3 +444,4 @@ var Icon = require('react-native-vector-icons/RNIMigration')
 This project is licenced under the [MIT License](http://opensource.org/licenses/mit-license.html).
 
 Any bundled fonts are copyright to their respective authors and mostly under MIT or [SIL OFL](http://scripts.sil.org/OFL).
+

--- a/fonts.gradle
+++ b/fonts.gradle
@@ -1,0 +1,53 @@
+/**
+ * Task to copy icon font files
+ */
+
+def config = project.hasProperty("vectoricons") ? project.vectoricons : [];
+
+def iconFontsDir = config.iconFontsDir ?: "../../node_modules/react-native-vector-icons/Fonts";
+def iconFontNames = config.iconFontNames ?: [ "*.ttf" ];
+
+gradle.projectsEvaluated {
+    // Grab all build types and product flavors
+    def buildTypes = android.buildTypes.collect { type -> type.name }
+    def productFlavors = android.productFlavors.collect { flavor -> flavor.name }
+
+    // When no product flavors defined, use empty
+    if (!productFlavors) productFlavors.add("")
+
+    productFlavors.each { productFlavorName ->
+        buildTypes.each { buildTypeName ->
+            // Create variant and target names
+            def targetName = "${productFlavorName.capitalize()}${buildTypeName.capitalize()}"
+            def targetPath = productFlavorName ?
+                    "${productFlavorName}/${buildTypeName}" :
+                    "${buildTypeName}"
+
+            // Create task for copying fonts
+            def currentFontTask = tasks.create(
+                    name: "copy${targetName}IconFonts",
+                    type: Copy) {
+                iconFontNames.each { name ->
+                    from(iconFontsDir)
+                    include(name)
+                    into("${buildDir}/intermediates/assets/${targetPath}/fonts/")
+                }
+            }
+
+            currentFontTask.dependsOn("merge${targetName}Resources")
+
+            [
+                "processArmeabi-v7a${targetName}Resources",
+                "processX86${targetName}Resources",
+                "processUniversal${targetName}Resources",
+                "process${targetName}Resources"
+            ].each { name ->
+                Task dependentTask = tasks.findByPath(name);
+
+                if (dependentTask != null) {
+                    dependentTask.dependsOn(currentFontTask)
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds a gradle script which will copy fonts automatically when building. Can be used as follows:

```gradle
project.ext.vectoricons = [
    iconFontNames: [ 'MaterialIcons.ttf', 'EvilIcons.ttf' ]
]

apply from: "../../node_modules/react-native/react.gradle"
apply from: "../../node_modules/react-native-vector-icons/fonts.gradle"
```

Sorry. Wanted to send this PR earlier (https://github.com/oblador/react-native-vector-icons/issues/65#issuecomment-165208660), but my script was not generic enough back then.