### PR TITLE
RN 0.25 compatibility

### DIFF
--- a/lib/create-icon-set.js
+++ b/lib/create-icon-set.js
@@ -9,7 +9,8 @@ var omit = require('lodash/omit');
 var isString = require('lodash/isString');
 var isEqual = require('lodash/isEqual');
 
-var React = require('react-native');
+var React = require('react');
+var ReactNative = require('react-native');
 var {
   View,
   Text,
@@ -22,7 +23,7 @@ var {
   PixelRatio,
   processColor,
   ToolbarAndroid,
-} = React;
+} = ReactNative;
 
 var NativeIconAPI = NativeModules.RNVectorIconsManager || NativeModules.RNVectorIconsModule;
 


### PR DESCRIPTION
In React Native 0.25, React Native stops wrapping shared React functionality (createClass, PropTypes etc. -- see https://github.com/facebook/react-native/commit/2eafcd45dbd42f750df1ab9aa3770fed5cdf11ae) and expects end users to import these from the react package instead. This PR implements that behavior.
