### PR TITLE
Updated to use the proper imports.

### DIFF
--- a/RNIMigration.js
+++ b/RNIMigration.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var React = require('react-native');
+var React = require('react');
 var FontAwesome = require('react-native-vector-icons/FontAwesome');
 var Foundation = require('react-native-vector-icons/Foundation');
 var Ionicons = require('react-native-vector-icons/Ionicons');

--- a/lib/create-icon-set.js
+++ b/lib/create-icon-set.js
@@ -9,7 +9,8 @@ var omit = require('lodash/omit');
 var isString = require('lodash/isString');
 var isEqual = require('lodash/isEqual');
 
-var React = require('react-native');
+var React = require('react');
+var ReactNative = require('react-native');
 var {
   View,
   Text,
@@ -22,7 +23,7 @@ var {
   PixelRatio,
   processColor,
   ToolbarAndroid,
-} = React;
+} = ReactNative;
 
 var NativeIconAPI = NativeModules.RNVectorIconsManager || NativeModules.RNVectorIconsModule;
 


### PR DESCRIPTION
React & ReactNative have been split in 0.25.0. This change is to add support for the split - don't merge until 0.25.0 is released (assuming this is a breaking change).