### PR TITLE
Fixed: warnings with react-native 0.25.x

### DIFF
--- a/lib/create-icon-set.js
+++ b/lib/create-icon-set.js
@@ -9,7 +9,8 @@ var omit = require('lodash/omit');
 var isString = require('lodash/isString');
 var isEqual = require('lodash/isEqual');
 
-var React = require('react-native');
+var React = require('react');
+var ReactNative = require('react-native');
 var {
   View,
   Text,
@@ -22,7 +23,7 @@ var {
   PixelRatio,
   processColor,
   ToolbarAndroid,
-} = React;
+} = ReactNative;
 
 var NativeIconAPI = NativeModules.RNVectorIconsManager || NativeModules.RNVectorIconsModule;
 
@@ -43,13 +44,13 @@ function createIconSet(glyphMap : Object, fontFamily : string, fontFile : string
     fontReference = fontFile.replace(/\.(otf|ttf)$/, '');
   }
 
-  var IconNamePropType = React.PropTypes.oneOf(Object.keys(glyphMap));
+  var IconNamePropType = ReactNative.PropTypes.oneOf(Object.keys(glyphMap));
 
-  var Icon = React.createClass({
+  var Icon = ReactNative.createClass({
     propTypes: {
       name: IconNamePropType.isRequired,
-      size: React.PropTypes.number,
-      color: React.PropTypes.string,
+      size: ReactNative.PropTypes.number,
+      color: ReactNative.PropTypes.string,
     },
     _root: (null:?Object),
 
@@ -105,7 +106,7 @@ function createIconSet(glyphMap : Object, fontFamily : string, fontFile : string
     },
   });
 
-  var IconButton = React.createClass({
+  var IconButton = ReactNative.createClass({
     getDefaultProps: function() {
       return {
         size: DEFAULT_BUTTON_ICON_SIZE,
@@ -200,11 +201,11 @@ function createIconSet(glyphMap : Object, fontFamily : string, fontFile : string
   };
 
 
-  var TabBarItemIOS = React.createClass({
+  var TabBarItemIOS = ReactNative.createClass({
     propTypes: {
       iconName: IconNamePropType.isRequired,
       selectedIconName: IconNamePropType,
-      iconSize: React.PropTypes.number,
+      iconSize: ReactNative.PropTypes.number,
     },
 
     updateIconSources: function(props) {
@@ -233,20 +234,20 @@ function createIconSet(glyphMap : Object, fontFamily : string, fontFile : string
     }
   });
 
-  var IconToolbarAndroid = React.createClass({
+  var IconToolbarAndroid = ReactNative.createClass({
     propTypes: {
       navIconName: IconNamePropType,
       overflowIconName: IconNamePropType,
-      actions: React.PropTypes.arrayOf(React.PropTypes.shape({
-        title: React.PropTypes.string.isRequired,
+      actions: ReactNative.PropTypes.arrayOf(ReactNative.PropTypes.shape({
+        title: ReactNative.PropTypes.string.isRequired,
         iconName: IconNamePropType,
-        iconSize: React.PropTypes.number,
-        iconColor: React.PropTypes.string,
-        show: React.PropTypes.oneOf(['always', 'ifRoom', 'never']),
-        showWithText: React.PropTypes.bool
+        iconSize: ReactNative.PropTypes.number,
+        iconColor: ReactNative.PropTypes.string,
+        show: ReactNative.PropTypes.oneOf(['always', 'ifRoom', 'never']),
+        showWithText: ReactNative.PropTypes.bool
       })),
-      iconSize: React.PropTypes.number,
-      iconColor: React.PropTypes.string,
+      iconSize: ReactNative.PropTypes.number,
+      iconColor: ReactNative.PropTypes.string,
     },
 
     updateIconSources: function(props) {


### PR DESCRIPTION
As of `0.25.x` `react-native` is deprecating `.cloneElement()` and `.createElement()`, and instead suggesting we use those methods from the `react` package as opposed to `react-native`.

This commit fixes those warnings.