### PR TITLE
fix: replaceState not available

### DIFF
--- a/lib/toolbar-android.js
+++ b/lib/toolbar-android.js
@@ -1,6 +1,6 @@
 import isEqual from 'lodash/isEqual';
-import omit from 'lodash/omit';
 import pick from 'lodash/pick';
+import reduce from 'lodash/reduce';
 
 import React, {
   Component,
@@ -68,7 +68,7 @@ export default function createToolbarAndroidComponent(IconNamePropType, getImage
           stateToEvict.push('icon');
         }
         if (this.state && stateToEvict.length) {
-          this.replaceState(omit(this.state, stateToEvict), () => this.updateIconSources(nextProps));
+          this.setState(reduce(stateToEvict, (state, keyToEvict) => ({...state, [keyToEvict]: false}), this.state), () => this.updateIconSources(nextProps));
         } else {
           this.updateIconSources(nextProps);
         }


### PR DESCRIPTION
This is a proposed fix to the problem described in issue #196.
As the `replaceState` function is not available on ES6 `class` components that extend `React.Component` (see [React documentation](https://facebook.github.io/react/docs/component-api.html#replacestate)), we use the `setState` and assign the value `false` to the keys to evict from the state. 