### PR TITLE
Avoid including react from react-native

### DIFF
--- a/RNIMigration.js
+++ b/RNIMigration.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var React = require('react-native');
+var React = require('react');
 var FontAwesome = require('react-native-vector-icons/FontAwesome');
 var Foundation = require('react-native-vector-icons/Foundation');
 var Ionicons = require('react-native-vector-icons/Ionicons');


### PR DESCRIPTION
Including react from react-native is a breaking change in v0.26.0.

See: https://github.com/facebook/react-native/releases/tag/v0.26.0