### PR TITLE
Fix a file name in the install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ These steps are optional and only needed if you want to use the `Icon.getImageSo
   }
   ```
 
-* Edit your `MainActivity.java` (deep in `android/app/src/main/java/...`) to look like this (note **two** places to edit):
+* Edit your `MainApplication.java` (deep in `android/app/src/main/java/...`) to look like this (note **two** places to edit):
 
   ```diff
   package com.myapp;


### PR DESCRIPTION
Hi,

I’ve just installed react-native-vector-icons on a newly created React-native (v0.29) project. I’m not sure if the generated configuration was modified recently but I least for my case the `getPackages` method was available in `MainApplication.java` instead of `MainActivity.java`.