### PR TITLE
Allow different icons per platform

### DIFF
--- a/lib/create-icon-set.js
+++ b/lib/create-icon-set.js
@@ -32,7 +32,10 @@ export default function createIconSet(glyphMap, fontFamily, fontFile) {
 
   class Icon extends Component {
     static propTypes = {
-      name: IconNamePropType.isRequired,
+      name: IconNamePropType,
+      ios: IconNamePropType,
+      android: IconNamePropType,
+      macos: IconNamePropType,
       size: PropTypes.number,
       color: PropTypes.string,
     };
@@ -49,9 +52,24 @@ export default function createIconSet(glyphMap, fontFamily, fontFile) {
     }
 
     render() {
-      const { name, size, color, style, ...props } = this.props;
+      const { name, ios, android, macos, size, color, style, ...props } = this.props;
 
-      let glyph = glyphMap[name] || '?';
+      let glyph;
+
+      switch (Platform.OS) {
+        case 'ios':
+          glyph = glyphMap[ios] || glyphMap[name] || '?';
+          break;
+        case 'android':
+          glyph = glyphMap[android] || glyphMap[name] || '?';
+          break;
+        case 'macos':
+          glyph = glyphMap[macos] || glyphMap[name] || '?';
+          break;
+        default:
+          glyphMap[name] || '?';
+      }
+
       if (typeof glyph === 'number') {
         glyph = String.fromCharCode(glyph);
       }


### PR DESCRIPTION
Adds props "ios", "android" & "macos" to specify an icon for each platform. "name" can still be used for all platforms, or as a fallback. 

Usage: 
<Icon android={"md-eye"} ios={"ios-eye"} size={20} color={"white"} />