### PR TITLE
README warning against wrong build.gradle

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Edit `Info.plist` as described above.
 
 This method has the advantage of fonts being copied from this module at build time so that the fonts and JS are always in sync, making upgrades painless.
 
-Edit `android/app/build.gradle` and add the following:
+Edit `android/app/build.gradle` ( NOT `android/build.gradle` ) and add the following:
 
 ```gradle
 apply from: "../../node_modules/react-native-vector-icons/fonts.gradle"


### PR DESCRIPTION
# Problem

When you apply : "../../node_modules/react-native-vector-icons/fonts.gradle" to android/build.gradle instead of android/app/buid.gradle, it fails to build, as in issue https://github.com/oblador/react-native-vector-icons/issues/215.

This is an easy mistake to make since I was editing this in Sublime and searched for file using command palette.
I also have no prior Android experience, so I did not expect many `build.gradle` files :)
In android/app/buid.gradle works perfectly fine.

I added a small warning. I know it's low-tech.
