### PR TITLE
Sometimes the hex character escape in content: is uppercase

### DIFF
--- a/lib/generate-icon-set-from-css.js
+++ b/lib/generate-icon-set-from-css.js
@@ -6,7 +6,7 @@ var _ = require('lodash');
 var fs = require('fs');
 
 function extractGlyphMapFromCss(files, selectorPattern) {
-  var styleRulePattern = '(\\.[A-Za-z0-9_.:, \\n\\t-]+)\\{[^}]*content: ?["\\\']\\\\([a-f0-9]+)["\\\'][^}]*\\}';
+  var styleRulePattern = '(\\.[A-Za-z0-9_.:, \\n\\t-]+)\\{[^}]*content: ?["\\\']\\\\([A-Fa-f0-9]+)["\\\'][^}]*\\}';
   var allStyleRules = new RegExp(styleRulePattern, 'g');
   var singleStyleRules = new RegExp(styleRulePattern);
   var allSelectors = new RegExp(selectorPattern, 'g');


### PR DESCRIPTION
Such as https://materialdesignicons.com/