### PR TITLE
added support for icon color @ tabbar

### DIFF
--- a/Examples/TabBarExample/index.ios.js
+++ b/Examples/TabBarExample/index.ios.js
@@ -142,6 +142,8 @@ class TabBarExample extends Component {
           title="Settings"
           iconName="ios-settings-outline"
           selectedIconName="ios-settings"
+          iconColor="#ffffff"
+          selectedIconColor="#000099"
           selected={this.state.selectedTab === 'settings'}
           onPress={() => {
             this.setState({

--- a/README.md
+++ b/README.md
@@ -241,8 +241,12 @@ Simply use `Icon.TabBarItemIOS` instead of `TabBarIOS.Item`. This is an extended
 |**`iconName`**|Name of the default icon (similar to `TabBarIOS.Item` `icon`)|*None*|
 |**`selectedIconName`**|Name of the selected icon (similar to `TabBarIOS.Item` `selectedIcon`). |*`iconName`*|
 |**`iconSize`**|Size of the icon. |`30`|
+|**`iconColor`**|Color of the icon. |*None*|
+|**`selectedIconColor`**|Color of the selected icon. |*`iconColor`*|
 
 For example usage see `Examples/TabBarExample` or the examples section below. Don't forget to import and link to this project as described above if you are going to use the TabBar integration. 
+
+**Note:** using `iconColor` and `selectedIconColor` requires the attribute [renderAsOriginal](https://facebook.github.io/react-native/docs/tabbarios-item.html#renderasoriginal) to be set to `true` on `Icon.TabBarItemIOS`.
 
 ## Usage with [NavigatorIOS](http://facebook.github.io/react-native/docs/navigatorios.html)
 

--- a/lib/tab-bar-item-ios.js
+++ b/lib/tab-bar-item-ios.js
@@ -16,18 +16,22 @@ export default function createTabBarItemIOSComponent(IconNamePropType, getImageS
       iconName: IconNamePropType.isRequired,
       selectedIconName: IconNamePropType,
       iconSize: PropTypes.number,
+      iconColor: PropTypes.string,
+      selectedIconColor: PropTypes.string
     };
 
     static defaultProps = {
       iconSize: 30,
+      iconColor: '#929292',
+      selectedIconColor: '#929292'
     };
 
     updateIconSources(props) {
       if (props.iconName) {
-        getImageSource(props.iconName, props.iconSize).then(icon => this.setState({ icon }));
+        getImageSource(props.iconName, props.iconSize, props.iconColor).then(icon => this.setState({ icon }));
       }
       if (props.selectedIconName) {
-        getImageSource(props.selectedIconName, props.iconSize).then(selectedIcon => this.setState({ selectedIcon }));
+        getImageSource(props.selectedIconName, props.iconSize, props.selectedIconColor).then(selectedIcon => this.setState({ selectedIcon }));
       }
     }
 

--- a/lib/tab-bar-item-ios.js
+++ b/lib/tab-bar-item-ios.js
@@ -17,21 +17,29 @@ export default function createTabBarItemIOSComponent(IconNamePropType, getImageS
       selectedIconName: IconNamePropType,
       iconSize: PropTypes.number,
       iconColor: PropTypes.string,
-      selectedIconColor: PropTypes.string
+      selectedIconColor: PropTypes.string,
     };
 
     static defaultProps = {
       iconSize: 30,
-      iconColor: '#929292',
-      selectedIconColor: '#929292'
     };
 
     updateIconSources(props) {
       if (props.iconName) {
-        getImageSource(props.iconName, props.iconSize, props.iconColor).then(icon => this.setState({ icon }));
+        if (props.iconColor) {
+          getImageSource(props.iconName, props.iconSize, props.iconColor).then(icon => this.setState({ icon }));
+        } else {
+          getImageSource(props.iconName, props.iconSize).then(icon => this.setState({ icon }));
+        }
       }
       if (props.selectedIconName) {
-        getImageSource(props.selectedIconName, props.iconSize, props.selectedIconColor).then(selectedIcon => this.setState({ selectedIcon }));
+        if (props.selectedIconColor) {
+          getImageSource(props.selectedIconName, props.iconSize, props.selectedIconColor).then(selectedIcon => this.setState({ selectedIcon }));
+        } else if (props.iconColor) {
+          getImageSource(props.selectedIconName, props.iconSize, props.iconColor).then(selectedIcon => this.setState({ selectedIcon }));
+        } else {
+          getImageSource(props.selectedIconName, props.iconSize).then(selectedIcon => this.setState({ selectedIcon }));
+        }
       }
     }
 


### PR DESCRIPTION
First draft for adding custom colors to the tabbar icons. Based on the changes one would use it in the following way (note the use of 'renderAsOriginal').

The example uses the Icon "users" from the Entypo iconset in two different colors.

```
import Icon from 'react-native-vector-icons/Entypo'

<Icon.TabBarItemIOS
    iconName='users'
    selectedIconName='users'
    iconColor='#ffffff'
    selectedIconColor='#000000'
    renderAsOriginal={true} />
```

Reason for the fix is due to the default grey template color being used otherwise. First time making a pull request so comments and/or help would be greatly appreciated!