### PR TITLE
[toolbar android] optimizing number of re-renders

### DIFF
--- a/lib/toolbar-android.js
+++ b/lib/toolbar-android.js
@@ -32,46 +32,6 @@ export default function createToolbarAndroidComponent(IconNamePropType, getImage
       actions: [],
     };
 
-    updateIconSources(props) {
-      const size = props.iconSize;
-      const color = props.iconColor || props.titleColor;
-
-      let iconsPromises = []
-      if (props.navIconName) {
-        iconsPromises.push(getImageSource(props.navIconName, size, color))
-      }
-      if (props.overflowIconName) {
-        iconsPromises.push(getImageSource(props.overflowIconName, size, color))
-      }
-
-      let actionsPromises = props.actions.map(action => {
-        if (action.iconName) {
-          return getImageSource(action.iconName, action.iconSize || size, action.iconColor || color)
-        } else {
-          return Promise.resolve(action);
-        }
-      })
-
-      Promise.all([...actionsPromises, ...iconsPromises])
-        .then((iconsAndActionIcons) => {
-          let newState = {ready: true}
-
-          newState.actions = props.actions.map((action, index) => {
-            return action.iconName ? {icon: iconsAndActionIcons[index], ...action} : action;
-          })
-
-          let shift = 0
-          if (props.navIconName) {
-            newState.navIcon = iconsAndActionIcons[props.actions.length + shift++];
-          }
-          if (props.overflowIconName) {
-            newState.overflowIcon = iconsAndActionIcons[props.actions.length + shift++];
-          }
-
-          this.setState(newState)
-        });
-    }
-
     constructor(props) {
       super(props);
       this.updateIconSources(props);
@@ -83,32 +43,56 @@ export default function createToolbarAndroidComponent(IconNamePropType, getImage
       };
     }
 
+    updateIconSources(props) {
+      const size = props.iconSize;
+      const color = props.iconColor || props.titleColor;
+
+      let allPromises = props.actions.map(action => {
+        if (action.iconName) {
+          return getImageSource(action.iconName, action.iconSize || size, action.iconColor || color);
+        } else {
+          return Promise.resolve(null);
+        }
+      })
+
+      if (props.navIconName) {
+        allPromises.push(getImageSource(props.navIconName, size, color));
+      }
+      if (props.overflowIconName) {
+        allPromises.push(getImageSource(props.overflowIconName, size, color));
+      }
+
+      Promise.all([...allPromises])
+        .then((allIcons) => {
+          let newState = {ready: true};
+
+          newState.actions = props.actions.map((action, index) => {
+            return action.iconName ? {icon: allIcons[index], ...action} : action;
+          })
+
+          let shift = 0;
+          newState.navIcon = props.navIconName && allIcons[props.actions.length + shift++];
+          newState.overflowIcon = props.overflowIconName && allIcons[props.actions.length + shift];
+
+          this.setState(newState);
+        });
+    }
+
     componentWillReceiveProps(nextProps) {
       const keys = Object.keys(IconToolbarAndroid.propTypes);
       if (!isEqual(pick(nextProps, keys), pick(this.props, keys))) {
-        // let stateToEvict = {};
-        // if (!nextProps.navIconName) {
-        //   stateToEvict.navIcon = undefined;
-        // }
-        // if (!nextProps.overflowIconName) {
-        //   stateToEvict.overflowIcon = undefined;
-        // }
-        // if (this.state && Object.keys(stateToEvict).length) {
-        //   this.setState(stateToEvict, () => this.updateIconSources(nextProps));
-        // } else {
-        this.setState({ready: false});
         this.updateIconSources(nextProps);
-        // }
       }
     }
 
     render() {
       // actions are both in props and state, we want the ones from state
-      const {actions, ...other} = this.props
+      const {actions, ...other} = this.props;
       if (!this.state.ready) {
         return <ToolbarAndroid {...other} />;
+      } else {
+        return <ToolbarAndroid {...other} {...this.state} />;
       }
-      return <ToolbarAndroid {...other} {...this.state} />;
     }
   };
 }

--- a/lib/toolbar-android.js
+++ b/lib/toolbar-android.js
@@ -50,10 +50,9 @@ export default function createToolbarAndroidComponent(IconNamePropType, getImage
       let allPromises = props.actions.map(action => {
         if (action.iconName) {
           return getImageSource(action.iconName, action.iconSize || size, action.iconColor || color);
-        } else {
-          return Promise.resolve(null);
         }
-      })
+        return Promise.resolve(null);
+      });
 
       if (props.navIconName) {
         allPromises.push(getImageSource(props.navIconName, size, color));
@@ -68,7 +67,7 @@ export default function createToolbarAndroidComponent(IconNamePropType, getImage
 
           newState.actions = props.actions.map((action, index) => {
             return action.iconName ? {icon: allIcons[index], ...action} : action;
-          })
+          });
 
           let shift = 0;
           newState.navIcon = props.navIconName && allIcons[props.actions.length + shift++];
@@ -90,9 +89,8 @@ export default function createToolbarAndroidComponent(IconNamePropType, getImage
       const {actions, ...other} = this.props;
       if (!this.state.ready) {
         return <ToolbarAndroid {...other} />;
-      } else {
-        return <ToolbarAndroid {...other} {...this.state} />;
       }
+      return <ToolbarAndroid {...other} {...this.state} />;
     }
   };
 }

--- a/lib/toolbar-android.js
+++ b/lib/toolbar-android.js
@@ -29,53 +29,88 @@ export default function createToolbarAndroidComponent(IconNamePropType, getImage
 
     static defaultProps = {
       iconSize: 24,
+      actions: [],
     };
 
     updateIconSources(props) {
       const size = props.iconSize;
       const color = props.iconColor || props.titleColor;
+
+      let iconsPromises = []
       if (props.navIconName) {
-        getImageSource(props.navIconName, size, color).then(navIcon => this.setState({ navIcon }));
+        iconsPromises.push(getImageSource(props.navIconName, size, color))
       }
       if (props.overflowIconName) {
-        getImageSource(props.overflowIconName, size, color).then(overflowIcon => this.setState({ overflowIcon }));
+        iconsPromises.push(getImageSource(props.overflowIconName, size, color))
       }
 
-      Promise.all((props.actions || []).map(action => {
+      let actionsPromises = props.actions.map(action => {
         if (action.iconName) {
-          return getImageSource(action.iconName, action.iconSize || size, action.iconColor || color).then(icon => ({
-            ...action,
-            icon,
-          }));
+          return getImageSource(action.iconName, action.iconSize || size, action.iconColor || color)
+        } else {
+          return Promise.resolve(action);
         }
-        return Promise.resolve(action);
-      })).then(actions => this.setState({ actions }));
+      })
+
+      Promise.all([...actionsPromises, ...iconsPromises])
+        .then((iconsAndActionIcons) => {
+          let newState = {ready: true}
+
+          newState.actions = props.actions.map((action, index) => {
+            if (action.iconName) {
+              return {icon: iconsAndActionIcons[index], ...action}
+            }
+            return action
+          })
+
+          let shift = 0
+          if (props.navIconName) {
+            newState.navIcon = iconsAndActionIcons[props.actions.length + shift++];
+          }
+          if (props.overflowIconName) {
+            newState.overflowIcon = iconsAndActionIcons[props.actions.length + shift++];
+          }
+
+          this.setState(newState)
+        });
     }
 
-    componentWillMount() {
-      this.updateIconSources(this.props);
+    constructor(props) {
+      super(props);
+      this.updateIconSources(props);
+      this.state = {
+        navIcon: undefined,
+        overflowIcon: undefined,
+        actions: undefined,
+        ready: false,
+      };
     }
 
     componentWillReceiveProps(nextProps) {
       const keys = Object.keys(IconToolbarAndroid.propTypes);
       if (!isEqual(pick(nextProps, keys), pick(this.props, keys))) {
-        let stateToEvict = {};
-        if (!nextProps.navIconName) {
-          stateToEvict.navIcon = undefined;
-        }
-        if (!nextProps.iconName) {
-          stateToEvict.icon = undefined;
-        }
-        if (this.state && Object.keys(stateToEvict).length) {
-          this.setState(stateToEvict, () => this.updateIconSources(nextProps));
-        } else {
-          this.updateIconSources(nextProps);
-        }
+        // let stateToEvict = {};
+        // if (!nextProps.navIconName) {
+        //   stateToEvict.navIcon = undefined;
+        // }
+        // if (!nextProps.overflowIconName) {
+        //   stateToEvict.overflowIcon = undefined;
+        // }
+        // if (this.state && Object.keys(stateToEvict).length) {
+        //   this.setState(stateToEvict, () => this.updateIconSources(nextProps));
+        // } else {
+        this.updateIconSources(nextProps);
+        // }
       }
     }
 
     render() {
-      return <ToolbarAndroid {...this.props} {...this.state} />;
+      // actions are both in props and state, we want the ones from state
+      const {actions, ...other} = this.props
+      if (!this.state.ready) {
+        return <ToolbarAndroid {...other} />;
+      }
+      return <ToolbarAndroid {...other} {...this.state} />;
     }
   };
 }

--- a/lib/toolbar-android.js
+++ b/lib/toolbar-android.js
@@ -96,6 +96,7 @@ export default function createToolbarAndroidComponent(IconNamePropType, getImage
         // if (this.state && Object.keys(stateToEvict).length) {
         //   this.setState(stateToEvict, () => this.updateIconSources(nextProps));
         // } else {
+        this.setState({ready: false});
         this.updateIconSources(nextProps);
         // }
       }

--- a/lib/toolbar-android.js
+++ b/lib/toolbar-android.js
@@ -57,7 +57,7 @@ export default function createToolbarAndroidComponent(IconNamePropType, getImage
           let newState = {ready: true}
 
           newState.actions = props.actions.map((action, index) => {
-            return action.iconName ? action : {icon: iconsAndActionIcons[index], ...action}
+            return action.iconName ? {icon: iconsAndActionIcons[index], ...action} : action;
           })
 
           let shift = 0

--- a/lib/toolbar-android.js
+++ b/lib/toolbar-android.js
@@ -57,10 +57,7 @@ export default function createToolbarAndroidComponent(IconNamePropType, getImage
           let newState = {ready: true}
 
           newState.actions = props.actions.map((action, index) => {
-            if (action.iconName) {
-              return {icon: iconsAndActionIcons[index], ...action}
-            }
-            return action
+            return action.iconName ? action : {icon: iconsAndActionIcons[index], ...action}
           })
 
           let shift = 0


### PR DESCRIPTION
hello oblador,
Thanks for the lib! Consider using the `Icon.Toolbar` with custom icons for overflow and navigation and these actions:

```
       let toolbarButtons = [
            {title: 'AAAA', iconName: 'search', show: 'always'},
            {title: 'BBBB', iconName: 'people', show: 'ifRoom'},
            {title: 'Settings', show: 'never'},
            {title: 'Log out', show: 'never'}
        ]
```

the current behavior is this: display the toolbar with the passed options. First render is like this:
![current](https://cloud.githubusercontent.com/assets/1566403/18346164/3c4b3f80-75bf-11e6-8b21-9310ecd97b2c.jpg)

Then, (if present) the navicon promise returns and triggers a re-render, then (if present) the overflow icon promise returns and re-renders and then the action icon promises return and trigger a re-render (the order might be different). In the end you get the toolbar with icons. **The problem** is the noticeable delay, where for a short moment you'd see the 'AAAA' and 'BBBB', even with dev mode is off and especially for the first render.

So what this PR does is that it renders this first:
![new](https://cloud.githubusercontent.com/assets/1566403/18346288/bc4b2c90-75bf-11e6-8b0e-0700dd2af06e.jpg)

And when all of the promises (navicon, overflow icon and action icons) return, it renders the toolbar with all the icons.
Now, I thought this would solve it, but actually, even after the icons are all loaded and the toolbar re-renders, there is still a noticeable transition from AAAA and BBBB to their icons (so the problem is probably somewhere even deeper), but (1) the transition is shorter than before and (2) this code does less re-renders than the current one, so I still think it is an improvement :D 

Now, as for the code in `componentWillReceiveProps` I don't understand what it was doing, so let me know if I should keep the previous code in there (and uncomment it) or if I should remove the commented part altogether. It seems to work fine like this.
