### PR TITLE
Fix IconExplorer for Android by adding application android:name to AndroidMainfest

### DIFF
--- a/Examples/IconExplorer/android/app/src/main/AndroidManifest.xml
+++ b/Examples/IconExplorer/android/app/src/main/AndroidManifest.xml
@@ -7,7 +7,8 @@
       android:allowBackup="true"
       android:label="@string/app_name"
       android:icon="@mipmap/ic_launcher"
-      android:theme="@style/AppTheme">
+      android:theme="@style/AppTheme"
+      android:name=".MainApplication">
       <activity
         android:name=".MainActivity"
         android:label="@string/app_name">


### PR DESCRIPTION
The app would crash and I saw the error described [here](https://github.com/facebook/react-native/issues/8215
) in the logs.


I've added `android:name` for `application` in the manifest file and that seemed to have solved the problem.