### PR TITLE
Fixed syntax error caused by stricter enforcement in babylon v6.11.3

### DIFF
--- a/lib/icon-button.js
+++ b/lib/icon-button.js
@@ -57,7 +57,7 @@ export default function createIconButtonComponent(Icon) {
         style,
         iconStyle,
         children,
-        ...props,
+        ...props
       } = this.props;
 
       let iconProps = pick(props, Object.keys(Text.propTypes), 'style', 'name', 'size', 'color');


### PR DESCRIPTION
Babylon "breaks the world" in [Babylon v6.11.3](https://github.com/babel/babylon/blob/1285131e3eb28ab6f5f62a7c5fd3ffd7ce1e5eb8/CHANGELOG.md#v6113-2016-10-01)

This change just makes `react-native-vector-icons` compatible with Babylon v6.11.3, released today, Oct 1