### PR TITLE
The import in the template should not be relative

### DIFF
--- a/template/iconSet.tpl
+++ b/template/iconSet.tpl
@@ -3,7 +3,7 @@
  * Usage: <${componentName} name="icon-name" size={20} color="#4F8EF7" />
  */
 
-import createIconSet from './lib/create-icon-set';
+import createIconSet from 'react-native-vector-icons/lib/create-icon-set';
 const glyphMap = ${glyphMap};
 
 let ${componentName} = createIconSet(glyphMap, '${fontFamily}', '${componentName}.ttf');


### PR DESCRIPTION
I changed the default template to include the node module rather than the relative path to the lib folder.
Most of the times a new icon set will be generated and import this way.