### PR TITLE
Update for RN@0.40.0 new header paths

### DIFF
--- a/Examples/IconExplorer/package.json
+++ b/Examples/IconExplorer/package.json
@@ -7,8 +7,8 @@
   },
   "dependencies": {
     "lodash": "^4.0.0",
-    "react": "15.3.2",
-    "react-native": "0.35.0",
+    "react": "15.4.1",
+    "react-native": "0.40.0",
     "react-native-vector-icons": "file:../../",
     "react-native-windows": "^0.35.0"
   },

--- a/Examples/TabBarExample/package.json
+++ b/Examples/TabBarExample/package.json
@@ -6,8 +6,8 @@
     "start": "node_modules/react-native/packager/packager.sh"
   },
   "dependencies": {
-    "react": "~15.3.0",
-    "react-native": "^0.32.0-rc.0",
+    "react": "15.4.1",
+    "react-native": "0.40.0",
     "react-native-vector-icons": "file:../../"
   }
 }

--- a/RNVectorIconsManager/RNVectorIconsManager.h
+++ b/RNVectorIconsManager/RNVectorIconsManager.h
@@ -6,8 +6,8 @@
 //  Copyright (c) 2015 Joel Arvidsson. All rights reserved.
 //
 
-#import "RCTBridgeModule.h"
-#import "RCTLog.h"
+#import <React/RCTBridgeModule.h>
+#import <React/RCTLog.h>
 
 @interface RNVectorIconsManager : NSObject <RCTBridgeModule>
 

--- a/RNVectorIconsManager/RNVectorIconsManager.m
+++ b/RNVectorIconsManager/RNVectorIconsManager.m
@@ -7,9 +7,9 @@
 //
 
 #import "RNVectorIconsManager.h"
-#import "RCTConvert.h"
-#import "RCTBridge.h"
-#import "RCTUtils.h"
+#import <React/RCTConvert.h>
+#import <React/RCTBridge.h>
+#import <React/RCTUtils.h>
 
 @implementation RNVectorIconsManager
 


### PR DESCRIPTION
React native has made a breaking change to header paths in 0.40.0 (https://github.com/facebook/react-native/releases/tag/v0.40.0)

So, it should fix this issue: #373