### PR TITLE
Added an option for Icons to display nothing as a placeholder

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ Any [Text property](http://facebook.github.io/react-native/docs/text.html) and t
 | Prop | Description | Default |
 |---|---|---|
 |**`size`**|Size of the icon, can also be passed as `fontSize` in the style object. |`12`|
-|**`name`**|What icon to show, see Icon Explorer app or one of the links above. |*None*|
+|**`name`**|What icon to show, see Icon Explorer app or one of the links above. [Rare case] Alternatively, you may want only an empty icon (e.g. as a placeholder), to do this you can set this property to `Icon.EMPTY_ICON_NAME`. |*None*|
 |**`color`**|Color of the icon. |*Inherited*|
 
 ### Styling

--- a/lib/create-icon-set.js
+++ b/lib/create-icon-set.js
@@ -19,6 +19,7 @@ const NativeIconAPI = (NativeModules.RNVectorIconsManager || NativeModules.RNVec
 
 const DEFAULT_ICON_SIZE = 12;
 const DEFAULT_ICON_COLOR = 'black';
+const EMPTY_ICON_NAME = '[empty]';
 
 export default function createIconSet(glyphMap, fontFamily, fontFile) {
   let fontReference = fontFamily;
@@ -31,7 +32,7 @@ export default function createIconSet(glyphMap, fontFamily, fontFile) {
     fontReference = `Assets/${fontFile}#${fontFamily}`;
   }
 
-  const IconNamePropType = PropTypes.oneOf(Object.keys(glyphMap));
+  const IconNamePropType = PropTypes.oneOf([EMPTY_ICON_NAME].concat(Object.keys(glyphMap)));
 
   class Icon extends Component {
     static propTypes = {
@@ -60,7 +61,7 @@ export default function createIconSet(glyphMap, fontFamily, fontFile) {
     render() {
       const { name, size, color, style, ...props } = this.props;
 
-      let glyph = glyphMap[name] || '?';
+      let glyph = glyphMap[name] || (name == EMPTY_ICON_NAME ? '' : '?');
       if (typeof glyph === 'number') {
         glyph = String.fromCharCode(glyph);
       }
@@ -129,6 +130,7 @@ export default function createIconSet(glyphMap, fontFamily, fontFile) {
   Icon.TabBarItemIOS = Icon.TabBarItem;
   Icon.ToolbarAndroid = createToolbarAndroidComponent(IconNamePropType, getImageSource);
   Icon.getImageSource = getImageSource;
+  Icon.EMPTY_ICON_NAME = EMPTY_ICON_NAME;
 
   return Icon;
 }


### PR DESCRIPTION
I've encountered a problem that I wanted to use an empty Icon. For example in a list where some of the items don't have an icon. More importantly, in third-party packages that use `react-native-vector-icons`, you don't have a lot of control, so having the option of using an empty icon that doesn't mess up the layout can be helpful.
