### PR TITLE
Accept content specified as actual character when generating icon set from css

### DIFF
--- a/lib/generate-icon-set-from-css.js
+++ b/lib/generate-icon-set-from-css.js
@@ -6,7 +6,7 @@ var _ = require('lodash');
 var fs = require('fs');
 
 function extractGlyphMapFromCss(files, selectorPattern) {
-  var styleRulePattern = '(\\.[A-Za-z0-9_.:, \\n\\t-]+)\\{[^}]*content: ?["\\\']\\\\([A-Fa-f0-9]+)["\\\'][^}]*\\}';
+  var styleRulePattern = '(\\.[A-Za-z0-9_.:, \\n\\t-]+)\\{[^}]*content: ?["\\\'](?:\\\\([A-Fa-f0-9]+)|([^"\\\']+))["\\\'][^}]*\\}';
   var allStyleRules = new RegExp(styleRulePattern, 'g');
   var singleStyleRules = new RegExp(styleRulePattern);
   var allSelectors = new RegExp(selectorPattern, 'g');
@@ -23,7 +23,8 @@ function extractGlyphMapFromCss(files, selectorPattern) {
     if(rules) {
       rules.forEach(function(rule) {
         var ruleParts = rule.match(singleStyleRules);
-        var charCode = parseInt(ruleParts[2], 16);
+        var hexCharCode = ruleParts[2], actualChar = ruleParts[3];
+        var charCode = hexCharCode ? parseInt(hexCharCode, 16) : (actualChar.length > 1 ? actualChar : actualChar.charCodeAt());
         var selectors = ruleParts[1].match(allSelectors);
         if(selectors) {
           selectors.forEach(function(selector) {


### PR DESCRIPTION
For example .icon-search:before {content:'🔎'}