### PR TITLE
Replace React.PropTypes by prop-types

### DIFF
--- a/RNIMigration.js
+++ b/RNIMigration.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import FontAwesome from 'react-native-vector-icons/FontAwesome';
 import Foundation from 'react-native-vector-icons/Foundation';
 import Ionicons from 'react-native-vector-icons/Ionicons';
@@ -19,9 +20,9 @@ const ICON_SET_MAP = {
 // react-native-icons module. Please don't use this component for new apps/views.
 export default class Icon extends React.Component {
   static propTypes = {
-    name: React.PropTypes.string.isRequired,
-    size: React.PropTypes.number,
-    color: React.PropTypes.string,
+    name: PropTypes.string.isRequired,
+    size: PropTypes.number,
+    color: PropTypes.string,
   };
 
   setNativeProps(nativeProps) {

--- a/directory/src/App.js
+++ b/directory/src/App.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import './App.css';
 import Entypo from '../../glyphmaps/Entypo.json';
 import EvilIcons from '../../glyphmaps/EvilIcons.json';

--- a/lib/create-icon-set.js
+++ b/lib/create-icon-set.js
@@ -1,7 +1,8 @@
 import React, {
   Component,
-  PropTypes,
 } from 'react';
+
+import PropTypes from 'prop-types';
 
 import {
   NativeModules,

--- a/lib/icon-button.js
+++ b/lib/icon-button.js
@@ -4,8 +4,9 @@ import pick from 'lodash/pick';
 
 import React, {
   Component,
-  PropTypes,
 } from 'react';
+
+import PropTypes from 'prop-types';
 
 import {
   StyleSheet,

--- a/lib/tab-bar-item-ios.js
+++ b/lib/tab-bar-item-ios.js
@@ -3,8 +3,9 @@ import pick from 'lodash/pick';
 
 import React, {
   Component,
-  PropTypes,
 } from 'react';
+
+import PropTypes from 'prop-types';
 
 import {
   TabBarIOS,

--- a/lib/toolbar-android.js
+++ b/lib/toolbar-android.js
@@ -3,8 +3,9 @@ import pick from 'lodash/pick';
 
 import React, {
   Component,
-  PropTypes,
 } from 'react';
+
+import PropTypes from 'prop-types';
 
 import {
   ToolbarAndroid,

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
   },
   "dependencies": {
     "lodash": "^4.0.0",
+    "prop-types": "^15.5.8",
     "yargs": "^6.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Replace deprecated usage of ```React.PropTypes``` by ```PropTypes``` from the ```prop-types``` package.