### PR TITLE
Support usage with cocoapods with `use_frameworks!`

### DIFF
--- a/lib/create-icon-set.js
+++ b/lib/create-icon-set.js
@@ -32,6 +32,12 @@ export default function createIconSet(glyphMap, fontFamily, fontFile) {
     fontReference = `Assets/${fontFile}#${fontFamily}`;
   }
 
+  if (Platform.OS === 'ios' && fontFile) {
+    NativeIconAPI.loadFontWithFileName(...fontFile.split('.')).catch(error =>
+      console.error(error)
+    );
+  }
+
   const IconNamePropType = PropTypes.oneOf(Object.keys(glyphMap));
 
   class Icon extends Component {


### PR DESCRIPTION
- Explicitly load font files from the module bundle without assuming they're present in the main app bundle

Closes #410 

Many thanks to @yimingtang for pointing out the solution in the issue linked above!