### PR TITLE
Fix issue 460

### DIFF
--- a/lib/icon-button.js
+++ b/lib/icon-button.js
@@ -39,7 +39,7 @@ const IOS7_BLUE = '#007AFF';
 export default function createIconButtonComponent(Icon) {
   return class IconButton extends Component {
     static propTypes = {
-      ...View.propTypes,
+      ...React.propTypes,
       backgroundColor: PropTypes.string,
       borderRadius: PropTypes.number,
       color: PropTypes.string,


### PR DESCRIPTION
Warnings using recent versions of React Native (React.PropTypes, React.createClass, View.propTypes)

https://github.com/oblador/react-native-vector-icons/issues/460