### PR TITLE
Update Gradle to solve problems with newer projects

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,7 +4,7 @@ buildscript {
   }
 
   dependencies {
-    classpath 'com.android.tools.build:gradle:1.1.3'
+    classpath 'com.android.tools.build:gradle:2.3.3'
   }
 }
 
@@ -12,7 +12,7 @@ apply plugin: 'com.android.library'
 
 android {
   compileSdkVersion 23
-  buildToolsVersion "23.0.1"
+  buildToolsVersion "26.0.0"
 
   defaultConfig {
     minSdkVersion 16


### PR DESCRIPTION
When trying to build React Native using this project on newer versions of the Android tools, we can no longer compile using so old tools.