### PR TITLE
Fixed deprecated Navigator usage in Android Icon Explorer example.

### DIFF
--- a/Examples/IconExplorer/index.android.js
+++ b/Examples/IconExplorer/index.android.js
@@ -2,13 +2,13 @@ import React, { Component } from 'react';
 import {
   AppRegistry,
   BackAndroid,
-  Navigator,
   StyleSheet,
   ToolbarAndroid,
   View,
 } from 'react-native';
 
 import Ionicons from 'react-native-vector-icons/Ionicons';
+import { Navigator } from 'react-native-deprecated-custom-components';
 import IconSetList from './IconSetList';
 import IconList from './IconList';
 

--- a/Examples/IconExplorer/package.json
+++ b/Examples/IconExplorer/package.json
@@ -9,6 +9,7 @@
     "lodash": "^4.0.0",
     "react": "16.0.0-alpha.6",
     "react-native": "0.44.0",
-    "react-native-vector-icons": "file:../../"
+    "react-native-vector-icons": "file:../../",
+    "react-native-deprecated-custom-components": "^0.1.0"
   }
 }


### PR DESCRIPTION
Android explorer examples are throwing an error : 

**Navigator is deprecated and has been removed from this package. It can now be installed and imported from react-native-deprecated-custom-components instead of react-native. Learn about alternative navigation solutions at http://facebook.github.io/react-native/docs/navigation.html**

<img src="https://user-images.githubusercontent.com/1889095/27973906-02f8052a-635c-11e7-9819-55e4888098e4.png" width="250" height="400" />

The Navigator is no longer part of `react-native` package and it's recommended now to use one of the community navigations, but at this point it would require more changes in the project so the simple fix is to use the 'react-native-deprecated-custom-components'. 

Sources: 
https://www.npmjs.com/package/react-native-deprecated-custom-components
https://github.com/facebookarchive/react-native-custom-components

Tested locally and works without any problems. Let me know if I should provide more details @oblador 