### PR TITLE
Remove createJSModules - RN 0.47 compatibility

### DIFF
--- a/android/src/main/java/com/oblador/vectoricons/VectorIconsPackage.java
+++ b/android/src/main/java/com/oblador/vectoricons/VectorIconsPackage.java
@@ -23,10 +23,6 @@ public class VectorIconsPackage implements ReactPackage {
     return modules;
   }
 
-  public List<Class<? extends JavaScriptModule>> createJSModules() {
-    return Collections.emptyList();
-  }
-
   @Override
   public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
     return Collections.emptyList();


### PR DESCRIPTION
[`createJSModules` is now not required on Android](https://github.com/facebook/react-native/commit/ce6fb337a146e6f261f2afb564aa19363774a7a8) from RN 0.47. I actually can't build an app on RN 0.47 without removing this method.