### PR TITLE
Remove createJSModules @override - RN 0.47

### DIFF
--- a/android/src/main/java/com/oblador/vectoricons/VectorIconsPackage.java
+++ b/android/src/main/java/com/oblador/vectoricons/VectorIconsPackage.java
@@ -22,7 +22,8 @@ public class VectorIconsPackage implements ReactPackage {
     modules.add(new VectorIconsModule(reactContext));
     return modules;
   }
-
+  
+  // Deprecated RN 0.47
   public List<Class<? extends JavaScriptModule>> createJSModules() {
     return Collections.emptyList();
   }


### PR DESCRIPTION
createJSModules is now not required on Android from RN 0.47. This is backwards compatible according to my tests.