### PR TITLE
Add support for color prop as number

### DIFF
--- a/lib/create-icon-set.js
+++ b/lib/create-icon-set.js
@@ -35,7 +35,7 @@ export default function createIconSet(glyphMap, fontFamily, fontFile) {
     static propTypes = {
       name: IconNamePropType,
       size: PropTypes.number,
-      color: PropTypes.string,
+      color: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
       children: PropTypes.node,
       style: PropTypes.any, // eslint-disable-line react/forbid-prop-types
     };

--- a/lib/icon-button.js
+++ b/lib/icon-button.js
@@ -29,7 +29,10 @@ const IOS7_BLUE = '#007AFF';
 export default function createIconButtonComponent(Icon) {
   return class IconButton extends Component {
     static propTypes = {
-      backgroundColor: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+      backgroundColor: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.number,
+      ]),
       borderRadius: PropTypes.number,
       color: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
       size: PropTypes.number,

--- a/lib/icon-button.js
+++ b/lib/icon-button.js
@@ -29,9 +29,9 @@ const IOS7_BLUE = '#007AFF';
 export default function createIconButtonComponent(Icon) {
   return class IconButton extends Component {
     static propTypes = {
-      backgroundColor: PropTypes.string,
+      backgroundColor: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
       borderRadius: PropTypes.number,
-      color: PropTypes.string,
+      color: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
       size: PropTypes.number,
       iconStyle: PropTypes.any, // eslint-disable-line react/forbid-prop-types
       style: PropTypes.any, // eslint-disable-line react/forbid-prop-types

--- a/lib/tab-bar-item-ios.js
+++ b/lib/tab-bar-item-ios.js
@@ -15,7 +15,10 @@ export default function createTabBarItemIOSComponent(
       selectedIconName: IconNamePropType,
       iconSize: PropTypes.number,
       iconColor: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-      selectedIconColor: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+      selectedIconColor: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.number,
+      ]),
     };
 
     static defaultProps = {

--- a/lib/tab-bar-item-ios.js
+++ b/lib/tab-bar-item-ios.js
@@ -14,8 +14,8 @@ export default function createTabBarItemIOSComponent(
       iconName: IconNamePropType.isRequired,
       selectedIconName: IconNamePropType,
       iconSize: PropTypes.number,
-      iconColor: PropTypes.string,
-      selectedIconColor: PropTypes.string,
+      iconColor: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+      selectedIconColor: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     };
 
     static defaultProps = {

--- a/lib/toolbar-android.js
+++ b/lib/toolbar-android.js
@@ -25,7 +25,7 @@ export default function createToolbarAndroidComponent(
         })
       ),
       iconSize: PropTypes.number,
-      iconColor: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),,
+      iconColor: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     };
 
     static defaultProps = {

--- a/lib/toolbar-android.js
+++ b/lib/toolbar-android.js
@@ -19,13 +19,13 @@ export default function createToolbarAndroidComponent(
           title: PropTypes.string.isRequired,
           iconName: IconNamePropType,
           iconSize: PropTypes.number,
-          iconColor: PropTypes.string,
+          iconColor: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
           show: PropTypes.oneOf(['always', 'ifRoom', 'never']),
           showWithText: PropTypes.bool,
         })
       ),
       iconSize: PropTypes.number,
-      iconColor: PropTypes.string,
+      iconColor: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),,
     };
 
     static defaultProps = {


### PR DESCRIPTION
Allow color prop to be a number, eg. (hex) `0xffee88` for opaque colors or `0x0000007f` for a transparent color.

The number can be non-hex, eg. `16772744` which is the same as `0xffee88`, but it is not as easy to read.

The reason for this support is because 'black' as a color is a lookup in a table to covert it to the number 0 (zero), and '#000000' or '#000' issues a string parser via a regex to convert to the exact same number - 0 (zero)! Same goes for any other color.

Behind the scenes react-native converts '#ffee88' to 16772744, but it is a few more checks,  computations and conversions. Keep in mind that `0xffee88` does not get "converted" to 16772744, since they are the same number, but written in different base. Internally, JavaScript interprets it as the exact same thing - a number.