### PR TITLE
Modify 'Header Search Path' for native iOS app to integrate react-nat…

### DIFF
--- a/RNVectorIcons.xcodeproj/project.pbxproj
+++ b/RNVectorIcons.xcodeproj/project.pbxproj
@@ -214,6 +214,7 @@
 					"$(SRCROOT)/../../React/**",
 					"$(SRCROOT)/../react-native/React/**",
 					"$(SRCROOT)/node_modules/react-native/React/**",
+					"$(BUILT_PRODUCTS_DIR)",
 				);
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -230,6 +231,7 @@
 					"$(SRCROOT)/../../React/**",
 					"$(SRCROOT)/../react-native/React/**",
 					"$(SRCROOT)/node_modules/react-native/React/**",
+					"$(BUILT_PRODUCTS_DIR)",
 				);
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";


### PR DESCRIPTION
Modify 'Header Search Path' for native iOS app to integrate react-native-vector-icons from react-native package.json.

```
In file included from /Users/OceanHorn/SourceTree/mmms/node_modules/react-native-vector-icons/RNVectorIconsManager/RNVectorIconsManager.m:9:
In file included from /Users/OceanHorn/SourceTree/mmms/node_modules/react-native-vector-icons/RNVectorIconsManager/RNVectorIconsManager.h:12:
../react-native/React/Base/RCTBridgeModule.h:12:9: fatal error: 'React/RCTDefines.h' file not found
#import <React/RCTDefines.h>
        ^~~~~~~~~~~~~~~~~~~~
1 error generated.

```