### PR TITLE
 Update build.gradle 

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,18 +1,19 @@
 buildscript {
   repositories {
     jcenter()
+    google()
   }
 
   dependencies {
-    classpath 'com.android.tools.build:gradle:2.3.+'
+    classpath 'com.android.tools.build:gradle:3.0.1'
   }
 }
 
 apply plugin: 'com.android.library'
 
 android {
-  compileSdkVersion 26
-  buildToolsVersion "26.0.1"
+  compileSdkVersion 27
+  buildToolsVersion "27.0.3"
 
   defaultConfig {
     minSdkVersion 16
@@ -30,5 +31,5 @@ repositories {
 }
 
 dependencies {
-  compile "com.facebook.react:react-native:+"
+  implementation "com.facebook.react:react-native:+"
 }


### PR DESCRIPTION
Updated gradle version, compileSdkVersion with the corresponding buildToolsVersion. Using implementation instead of compile as of gradle 3.0.1.