### PR TITLE
Add hasIcon static method API

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,8 @@ Any [Text property](http://facebook.github.io/react-native/docs/text.html) and t
 |**`name`**|What icon to show, see Icon Explorer app or one of the links above. |*None*|
 |**`color`**|Color of the icon. |*Inherited*|
 
+You can use `Icon.hasIcon(name)` to check if the name is valid in current icon set.
+
 ### Styling
 Since `Icon` builds on top of the `Text` component, most [style properties](http://facebook.github.io/react-native/docs/style.html) will work as expected, you might find it useful to play around with these:
 

--- a/lib/create-icon-set.js
+++ b/lib/create-icon-set.js
@@ -44,11 +44,11 @@ export default function createIconSet(glyphMap, fontFamily, fontFile) {
       size: DEFAULT_ICON_SIZE,
       allowFontScaling: false,
     };
- 
+
     static hasIcon(name) {
       return Object.keys(glyphMap).includes(name);
     }
- 
+
     setNativeProps(nativeProps) {
       if (this.root) {
         this.root.setNativeProps(nativeProps);

--- a/lib/create-icon-set.js
+++ b/lib/create-icon-set.js
@@ -44,7 +44,11 @@ export default function createIconSet(glyphMap, fontFamily, fontFile) {
       size: DEFAULT_ICON_SIZE,
       allowFontScaling: false,
     };
-
+  
+    static hasIcon(name) {
+      return Object.keys(glyphMap).includes(name);
+    }
+  
     setNativeProps(nativeProps) {
       if (this.root) {
         this.root.setNativeProps(nativeProps);

--- a/lib/create-icon-set.js
+++ b/lib/create-icon-set.js
@@ -44,11 +44,11 @@ export default function createIconSet(glyphMap, fontFamily, fontFile) {
       size: DEFAULT_ICON_SIZE,
       allowFontScaling: false,
     };
-  
+ 
     static hasIcon(name) {
       return Object.keys(glyphMap).includes(name);
     }
-  
+ 
     setNativeProps(nativeProps) {
       if (this.root) {
         this.root.setNativeProps(nativeProps);

--- a/lib/create-icon-set.js
+++ b/lib/create-icon-set.js
@@ -45,10 +45,6 @@ export default function createIconSet(glyphMap, fontFamily, fontFile) {
       allowFontScaling: false,
     };
 
-    static hasIcon(name) {
-      return Object.keys(glyphMap).includes(name);
-    }
-
     setNativeProps(nativeProps) {
       if (this.root) {
         this.root.setNativeProps(nativeProps);
@@ -163,6 +159,10 @@ export default function createIconSet(glyphMap, fontFamily, fontFile) {
     return Promise.resolve();
   }
 
+  function hasIcon(name) {
+    return Object.prototype.hasOwnProperty.call(glyphMap, name);
+  }
+
   Icon.Button = createIconButtonComponent(Icon);
   Icon.TabBarItem = createTabBarItemIOSComponent(
     IconNamePropType,
@@ -175,6 +175,7 @@ export default function createIconSet(glyphMap, fontFamily, fontFile) {
   );
   Icon.getImageSource = getImageSource;
   Icon.loadFont = loadFont;
+  Icon.hasIcon = hasIcon;
 
   return Icon;
 }


### PR DESCRIPTION
## Use Case

When using mixed icon sets in one project (e.g `MaterialIcons` and `MaterialCommunityIcons`) sometime you want to create an uniformed interface for easier use. (e.g `MaterialCommunityIcons` as fallback set).

Currently we don't have an API to check if some name is valid for one icon set. So I build the static util method `hasIcon` for this.