### PR TITLE
@kanalasumant/upgrade to react16.3

### DIFF
--- a/Examples/IconExplorer/IconList.js
+++ b/Examples/IconExplorer/IconList.js
@@ -72,7 +72,7 @@ export default class IconList extends PureComponent {
     }
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     const glyphs = this.getFilteredGlyphs(nextProps.iconSet, this.state.filter);
     this.setState({
       dataSource: this.state.dataSource.cloneWithRows(glyphs),

--- a/Examples/TabBarExample/index.ios.js
+++ b/Examples/TabBarExample/index.ios.js
@@ -39,7 +39,7 @@ const styles = StyleSheet.create({
 });
 
 class ColoredView extends PureComponent {
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     Icon.getImageSource('md-arrow-back', 30).then((source) => this.setState({ backIcon: source }));
   }
 
@@ -74,7 +74,7 @@ class TabBarExample extends PureComponent {
     };
   }
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     // https://github.com/facebook/react-native/issues/1403 prevents this to work for initial load
     Icon.getImageSource('ios-settings', 30).then((source) => this.setState({ gearIcon: source }));
   }

--- a/lib/tab-bar-item-ios.js
+++ b/lib/tab-bar-item-ios.js
@@ -25,11 +25,11 @@ export default function createTabBarItemIOSComponent(
       iconSize: 30,
     };
 
-    componentWillMount() {
+    UNSAFE_componentWillMount() {
       this.updateIconSources(this.props);
     }
 
-    componentWillReceiveProps(nextProps) {
+    UNSAFE_componentWillReceiveProps(nextProps) {
       const keys = Object.keys(TabBarItemIOS.propTypes);
       if (!isEqual(pick(nextProps, keys), pick(this.props, keys))) {
         this.updateIconSources(nextProps);

--- a/lib/toolbar-android.js
+++ b/lib/toolbar-android.js
@@ -32,11 +32,11 @@ export default function createToolbarAndroidComponent(
       iconSize: 24,
     };
 
-    componentWillMount() {
+    UNSAFE_componentWillMount() {
       this.updateIconSources(this.props);
     }
 
-    componentWillReceiveProps(nextProps) {
+    UNSAFE_componentWillReceiveProps(nextProps) {
       const keys = Object.keys(IconToolbarAndroid.propTypes);
       if (!isEqual(pick(nextProps, keys), pick(this.props, keys))) {
         const stateToEvict = {};


### PR DESCRIPTION
Pushing support for React v16.3 and React-Native v0.54 and up by replacing componentWillMount with UNSAFE_componentWillMount and componentWillReceiveProps with UNSAFE_componentWillReceiveProps. I apologize I didn't have the time to test if it works with the latest versions of React i.e v16.3 and React-Native v0.54. Please feel free to test the functionality thoroughly before merging with master. Thanks!