### PR TITLE
Improves default Android button and allows no text

### DIFF
--- a/lib/icon-button.js
+++ b/lib/icon-button.js
@@ -1,9 +1,10 @@
 import isString from 'lodash/isString';
 import omit from 'lodash/omit';
 import pick from 'lodash/pick';
+import defaults from 'lodash/defaults';
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import { StyleSheet, Text, TouchableHighlight, View } from './react-native';
+import { Platform, StyleSheet, Text, TouchableHighlight, View } from './react-native';
 
 const styles = StyleSheet.create({
   container: {
@@ -14,6 +15,7 @@ const styles = StyleSheet.create({
   },
   touchable: {
     overflow: 'hidden',
+    elevation: 5,
   },
   icon: {
     marginRight: 10,
@@ -25,6 +27,7 @@ const styles = StyleSheet.create({
 });
 
 const IOS7_BLUE = '#007AFF';
+const ANDROID_BLUE = '#2196F3';
 
 export default function createIconButtonComponent(Icon) {
   return class IconButton extends PureComponent {
@@ -42,8 +45,8 @@ export default function createIconButtonComponent(Icon) {
     };
 
     static defaultProps = {
-      backgroundColor: IOS7_BLUE,
-      borderRadius: 5,
+      backgroundColor: Platform.OS == 'android'? ANDROID_BLUE : IOS7_BLUE,
+      borderRadius: Platform.OS == 'android'? 3 : 5,
       color: 'white',
       size: 20,
     };
@@ -71,7 +74,8 @@ export default function createIconButtonComponent(Icon) {
         'borderRadius',
         'backgroundColor'
       );
-      iconProps.style = iconStyle ? [styles.icon, iconStyle] : styles.icon;
+      const defaultIconStyle = children? styles.icon : defaults({ marginRight: 0 }, styles.icon);
+      iconProps.style = iconStyle ? [defaultIconStyle, iconStyle] : defaultIconStyle;
 
       const colorStyle = pick(this.props, 'color');
       const blockStyle = pick(this.props, 'backgroundColor', 'borderRadius');
@@ -84,7 +88,9 @@ export default function createIconButtonComponent(Icon) {
           <View style={[styles.container, blockStyle, style]} {...props}>
             <Icon {...iconProps} />
             {isString(children) ? (
-              <Text style={[styles.text, colorStyle]}>{children}</Text>
+              <Text style={[styles.text, colorStyle]}>
+                {Platform.OS == 'android'? children.toUpperCase() : children}
+              </Text>
             ) : (
               children
             )}


### PR DESCRIPTION
Making the button much similar to the default Android one, and allowing buttons without text (that originally had an empty space on the right).

Below are two `Icon.Button` and a `Button`.
![selection_014](https://user-images.githubusercontent.com/532299/38134295-bd9c4c80-33e8-11e8-8d1c-47ce3e55da63.png)
