### PR TITLE
Using SDK Version variables from root project

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -10,13 +10,13 @@ buildscript {
 
 apply plugin: 'com.android.library'
 
-def _ext = rootProject.ext
+def ext = rootProject.ext
 
-def _reactNativeVersion = _ext.has('reactNative') ? _ext.reactNative : '+'
-def _compileSdkVersion = _ext.has('compileSdkVersion') ? _ext.compileSdkVersion : 27
-def _buildToolsVersion = _ext.has('buildToolsVersion') ? _ext.buildToolsVersion : '27.0.3'
-def _minSdkVersion = _ext.has('minSdkVersion') ? _ext.minSdkVersion : 16
-def _targetSdkVersion = _ext.has('targetSdkVersion') ? _ext.targetSdkVersion : 27
+def reactNativeVersion = ext.has('reactNative') ? ext.reactNative : '+'
+def _compileSdkVersion = ext.has('compileSdkVersion') ? ext.compileSdkVersion : 27
+def _buildToolsVersion = ext.has('buildToolsVersion') ? ext.buildToolsVersion : '27.0.3'
+def _minSdkVersion = ext.has('minSdkVersion') ? ext.minSdkVersion : 16
+def _targetSdkVersion = ext.has('targetSdkVersion') ? ext.targetSdkVersion : 27
 
 android {
   compileSdkVersion _compileSdkVersion
@@ -38,5 +38,5 @@ repositories {
 }
 
 dependencies {
-  compile "com.facebook.react:react-native:${_reactNativeVersion}"
+  compile "com.facebook.react:react-native:${reactNativeVersion}"
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -12,19 +12,19 @@ apply plugin: 'com.android.library'
 
 def ext = rootProject.ext
 
-def reactNativeVersion = ext.has('reactNative') ? ext.reactNative : '+'
-def _compileSdkVersion = ext.has('compileSdkVersion') ? ext.compileSdkVersion : 27
-def _buildToolsVersion = ext.has('buildToolsVersion') ? ext.buildToolsVersion : '27.0.3'
-def _minSdkVersion = ext.has('minSdkVersion') ? ext.minSdkVersion : 16
-def _targetSdkVersion = ext.has('targetSdkVersion') ? ext.targetSdkVersion : 27
+def projectReactNativeVersion = ext.has('reactNativeVersion') ? ext.reactNativeVersion : '+'
+def projectCompileSdkVersion = ext.has('compileSdkVersion') ? ext.compileSdkVersion : 27
+def projectBuildToolsVersion = ext.has('buildToolsVersion') ? ext.buildToolsVersion : '27.0.3'
+def projectMinSdkVersion = ext.has('minSdkVersion') ? ext.minSdkVersion : 16
+def projectTargetSdkVersion = ext.has('targetSdkVersion') ? ext.targetSdkVersion : 27
 
 android {
-  compileSdkVersion _compileSdkVersion
-  buildToolsVersion _buildToolsVersion
+  compileSdkVersion projectCompileSdkVersion
+  buildToolsVersion projectBuildToolsVersion
 
   defaultConfig {
-    minSdkVersion _minSdkVersion
-    targetSdkVersion _targetSdkVersion
+    minSdkVersion projectMinSdkVersion
+    targetSdkVersion projectTargetSdkVersion
     versionCode 1
     versionName "1.0"
   }
@@ -38,5 +38,5 @@ repositories {
 }
 
 dependencies {
-  compile "com.facebook.react:react-native:${reactNativeVersion}"
+  compile "com.facebook.react:react-native:${projectReactNativeVersion}"
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -10,13 +10,21 @@ buildscript {
 
 apply plugin: 'com.android.library'
 
+def _ext = rootProject.ext
+
+def _reactNativeVersion = _ext.has('reactNative') ? _ext.reactNative : '+'
+def _compileSdkVersion = _ext.has('compileSdkVersion') ? _ext.compileSdkVersion : 27
+def _buildToolsVersion = _ext.has('buildToolsVersion') ? _ext.buildToolsVersion : '27.0.3'
+def _minSdkVersion = _ext.has('minSdkVersion') ? _ext.minSdkVersion : 16
+def _targetSdkVersion = _ext.has('targetSdkVersion') ? _ext.targetSdkVersion : 27
+
 android {
-  compileSdkVersion 26
-  buildToolsVersion "26.0.1"
+  compileSdkVersion _compileSdkVersion
+  buildToolsVersion _buildToolsVersion
 
   defaultConfig {
-    minSdkVersion 16
-    targetSdkVersion 26
+    minSdkVersion _minSdkVersion
+    targetSdkVersion _targetSdkVersion
     versionCode 1
     versionName "1.0"
   }
@@ -30,5 +38,5 @@ repositories {
 }
 
 dependencies {
-  compile "com.facebook.react:react-native:+"
+  compile "com.facebook.react:react-native:${_reactNativeVersion}"
 }


### PR DESCRIPTION
Instead of assuming the `compileSdkVersion`, `targetSdkVersion`, etc, read it from the root project.
Default `compileSdkVersion` and `targetSdkVersion` to the latest versions.

Android Target API Level 26 will be required in August 2018.
https://android-developers.googleblog.com/2017/12/improving-app-security-and-performance.html
And the React Native team is already working on this:
facebook/react-native#17741
facebook/react-native#18095