### PR TITLE
Fix mismatched fontFamily & fontFile 

### DIFF
--- a/Foundation.js
+++ b/Foundation.js
@@ -6,7 +6,7 @@
 import createIconSet from './lib/create-icon-set';
 import glyphMap from './glyphmaps/Foundation.json';
 
-const iconSet = createIconSet(glyphMap, 'fontcustom', 'Foundation.ttf');
+const iconSet = createIconSet(glyphMap, 'Foundation', 'Foundation.ttf');
 
 export default iconSet;
 

--- a/MaterialCommunityIcons.js
+++ b/MaterialCommunityIcons.js
@@ -6,7 +6,7 @@
 import createIconSet from './lib/create-icon-set';
 import glyphMap from './glyphmaps/MaterialCommunityIcons.json';
 
-const iconSet = createIconSet(glyphMap, 'Material Design Icons', 'MaterialCommunityIcons.ttf');
+const iconSet = createIconSet(glyphMap, 'MaterialCommunityIcons', 'MaterialCommunityIcons.ttf');
 
 export default iconSet;
 

--- a/MaterialIcons.js
+++ b/MaterialIcons.js
@@ -6,7 +6,7 @@
 import createIconSet from './lib/create-icon-set';
 import glyphMap from './glyphmaps/MaterialIcons.json';
 
-const iconSet = createIconSet(glyphMap, 'Material Icons', 'MaterialIcons.ttf');
+const iconSet = createIconSet(glyphMap, 'MaterialIcons', 'MaterialIcons.ttf');
 
 export default iconSet;
 

--- a/SimpleLineIcons.js
+++ b/SimpleLineIcons.js
@@ -6,7 +6,7 @@
 import createIconSet from './lib/create-icon-set';
 import glyphMap from './glyphmaps/SimpleLineIcons.json';
 
-const iconSet = createIconSet(glyphMap, 'simple-line-icons', 'SimpleLineIcons.ttf');
+const iconSet = createIconSet(glyphMap, 'SimpleLineIcons', 'SimpleLineIcons.ttf');
 
 export default iconSet;
 

--- a/Zocial.js
+++ b/Zocial.js
@@ -6,7 +6,7 @@
 import createIconSet from './lib/create-icon-set';
 import glyphMap from './glyphmaps/Zocial.json';
 
-const iconSet = createIconSet(glyphMap, 'zocial', 'Zocial.ttf');
+const iconSet = createIconSet(glyphMap, 'Zocial', 'Zocial.ttf');
 
 export default iconSet;
 


### PR DESCRIPTION
Currently, some of the Icon Sets have mismatched `fontFamily` & `fontFile` arguments, which can lead to confusion when injecting font faces, as the readme does not specify the differences. See #667  for an example.

This PR changes all mismatched `fontFamily` arguments to match the respective `fontFile` argument, which is consistent with the readme & icon directory site.

Alternatively, if @oblador you prefer, you can change the README.md to reflect these differences.