### PR TITLE
Updates README to the correct IcoMoon file path

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,7 +352,7 @@ const Icon = createIconSetFromFontello(fontelloConfig);
 ### `createIconSetFromIcoMoon(config[, fontFamily[, fontFile]])`
 ```js
 import { createIconSetFromIcoMoon } from 'react-native-vector-icons';
-import icoMoonConfig from './config.json';
+import icoMoonConfig from './selection.json';
 const Icon = createIconSetFromIcoMoon(icoMoonConfig);
 ```
 


### PR DESCRIPTION
IcoMoon font exports generate a `selection.json`, not a `config.json` (like Fontello) does. 

This just updates the readme to reflect that