### PR TITLE
Exposes the glyph map with Icon.getRawGlyphMap

### DIFF
--- a/lib/create-icon-set.js
+++ b/lib/create-icon-set.js
@@ -163,6 +163,10 @@ export default function createIconSet(glyphMap, fontFamily, fontFile) {
     return Object.prototype.hasOwnProperty.call(glyphMap, name);
   }
 
+  function getRawGlyphMap() {
+    return glyphMap;
+  }
+
   Icon.Button = createIconButtonComponent(Icon);
   Icon.TabBarItem = createTabBarItemIOSComponent(
     IconNamePropType,
@@ -176,6 +180,7 @@ export default function createIconSet(glyphMap, fontFamily, fontFile) {
   Icon.getImageSource = getImageSource;
   Icon.loadFont = loadFont;
   Icon.hasIcon = hasIcon;
+  Icon.getRawGlyphMap = getRawGlyphMap;
 
   return Icon;
 }


### PR DESCRIPTION
Hi,

because of an advanced use-case in our app, we really need to be able to get glyphs manually, and pass them to a Text component on our own.

This PR exposes the raw glyph map.