### PR TITLE
react-native link now points to this specific pkg

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ If you want to use the TabBar/NavigatorIOS integration or use `getImageSource`, 
 
 #### Option: With `react-native link`
 
-`$ react-native link`
+`$ react-native link react-native-vector-icons`
 
 *Note: Some users are having trouble using this method, try one of the others if you are too.*
 


### PR DESCRIPTION
Updated readme so `react-native link` points to this specific package