### PR TITLE
fix platform version in podspec

### DIFF
--- a/RNVectorIcons.podspec
+++ b/RNVectorIcons.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.homepage       = "https://github.com/oblador/react-native-vector-icons"
   s.license        = "MIT"
   s.author         = { "Joel Arvidsson" => "joel@oblador.se" }
-  s.platform       = :ios, "7.0"
+  s.platform       = :ios, "9.0"
   s.source         = { :git => "https://github.com/oblador/react-native-vector-icons.git", :tag => "v#{s.version}" }
   s.source_files   = 'RNVectorIconsManager/**/*.{h,m}'
   s.resources      = "Fonts/*.ttf"


### PR DESCRIPTION
Thank you for a great library.
I found a warning on iOS, so I fixed it.

NOTE: Platform version in React.podspec is iOS9.0+.
https://github.com/facebook/react-native/blob/0926373c9f6e5191fe2253534576ea8a9fd3c7ab/React.podspec#L41


![2018-08-16 2 40 07](https://user-images.githubusercontent.com/4954289/44163538-b85c6380-a0fe-11e8-84d4-e65417a4215f.png)
