### PR TITLE
Fix line-height to icon size

### DIFF
--- a/lib/create-icon-set.js
+++ b/lib/create-icon-set.js
@@ -74,6 +74,7 @@ export default function createIconSet(
 
       const styleDefaults = {
         fontSize: size,
+        lineHeight: size,
         color,
       };
 


### PR DESCRIPTION
React Native Vector Icons passes style props down to React Native's `Text` component. Because RNVI does not specify a line-height value, the `Text` component defaults to `lineHeight: 'normal'`. This can result in icons that are taller than expected when using RNVI with React Native Web, because, as stated on [MDN](
https://developer.mozilla.org/en-US/docs/Web/CSS/line-height):

> Desktop browsers (including Firefox) use a default value of roughly 1.2, depending on the element's font-family.

This PR ensures the icon size is always passed as the `lineHeight` to avoid this issue.