### PR TITLE
Allows to place Icon to the Right of Icon.Button

### DIFF
--- a/lib/icon-button.js
+++ b/lib/icon-button.js
@@ -15,8 +15,11 @@ const styles = StyleSheet.create({
   touchable: {
     overflow: 'hidden',
   },
-  icon: {
+  iconLeft: {
     marginRight: 10,
+  },
+  iconRight: {
+    marginLeft: 10,
   },
   text: {
     fontWeight: '600',
@@ -36,6 +39,7 @@ export default function createIconButtonComponent(Icon) {
       borderRadius: PropTypes.number,
       color: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
       size: PropTypes.number,
+      iconRight: PropTypes.bool,
       iconStyle: PropTypes.any, // eslint-disable-line react/forbid-prop-types
       style: PropTypes.any, // eslint-disable-line react/forbid-prop-types
       children: PropTypes.node,
@@ -49,7 +53,13 @@ export default function createIconButtonComponent(Icon) {
     };
 
     render() {
-      const { style, iconStyle, children, ...restProps } = this.props;
+      const {
+        style,
+        iconStyle,
+        children,
+        iconRight,
+        ...restProps
+      } = this.props;
 
       const iconProps = pick(
         restProps,
@@ -71,17 +81,25 @@ export default function createIconButtonComponent(Icon) {
         'borderRadius',
         'backgroundColor'
       );
-      iconProps.style = iconStyle ? [styles.icon, iconStyle] : styles.icon;
 
       const colorStyle = pick(this.props, 'color');
       const blockStyle = pick(this.props, 'backgroundColor', 'borderRadius');
+
+      const containerStyles = iconRight
+        ? [styles.container, { flexDirection: 'row-reverse' }]
+        : [styles.container];
+
+      const properIconStyle = iconRight ? styles.iconRight : styles.iconLeft;
+      iconProps.style = iconStyle
+        ? [properIconStyle, iconStyle]
+        : properIconStyle;
 
       return (
         <TouchableHighlight
           style={[styles.touchable, blockStyle]}
           {...touchableProps}
         >
-          <View style={[styles.container, blockStyle, style]} {...props}>
+          <View style={[...containerStyles, blockStyle, style]} {...props}>
             <Icon {...iconProps} />
             {isString(children) ? (
               <Text style={[styles.text, colorStyle]}>{children}</Text>


### PR DESCRIPTION
Hello!

Since [0.29.0](https://github.com/facebook/react-native/releases/tag/v0.29.0) version of react-native, we can use the `row-reverse` value on `flexDirection` to reverse the order of flexbox items.

So, instead of doing this change by myself in every project, I think that it's a good idea to add a special `iconRight` props to the `Icon.Button` component.

Somes issues can be satisfied by this PR:

- https://github.com/oblador/react-native-vector-icons/issues/258
- https://github.com/oblador/react-native-vector-icons/issues/217

:wave: 