### PR TITLE
remove require cycle warning in React Native 0.57

### DIFF
--- a/lib/ensure-native-module-available.js
+++ b/lib/ensure-native-module-available.js
@@ -1,6 +1,6 @@
-import { Platform } from './react-native';
+import { Platform ,NativeModules} from './react-native';
 
-import { NativeIconAPI } from './create-icon-set';
+const NativeIconAPI = NativeModules.RNVectorIconsManager || NativeModules.RNVectorIconsModule;
 
 export default function ensureNativeModuleAvailable() {
   if (!NativeIconAPI) {

--- a/lib/ensure-native-module-available.js
+++ b/lib/ensure-native-module-available.js
@@ -1,4 +1,4 @@
-import { Platform ,NativeModules} from './react-native';
+import { Platform, NativeModules} from './react-native';
 
 const NativeIconAPI = NativeModules.RNVectorIconsManager || NativeModules.RNVectorIconsModule;
 

--- a/lib/ensure-native-module-available.js
+++ b/lib/ensure-native-module-available.js
@@ -1,6 +1,7 @@
-import { Platform, NativeModules} from './react-native';
+import { Platform, NativeModules } from './react-native';
 
-const NativeIconAPI = NativeModules.RNVectorIconsManager || NativeModules.RNVectorIconsModule;
+const NativeIconAPI =
+  NativeModules.RNVectorIconsManager || NativeModules.RNVectorIconsModule;
 
 export default function ensureNativeModuleAvailable() {
   if (!NativeIconAPI) {


### PR DESCRIPTION
Require Cycle: create-icon-set.js<->ensure-native-module-available.js