### PR TITLE
Fix compatible problem with Android Gradle Plugin

### DIFF
--- a/fonts.gradle
+++ b/fonts.gradle
@@ -33,6 +33,9 @@ gradle.projectsEvaluated {
                     from(iconFontsDir)
                     include(name)
                     into("${buildDir}/intermediates/assets/${targetPath}/fonts/")
+                    
+                    // compatible with Android Gradle Plugin 3.2+ new asset directory
+                    into("${buildDir}/intermediates/merged_assets/${targetPath}/merge${targetName}Assets/out/fonts/")
                 }
             }
 


### PR DESCRIPTION
From Android Gradle Plugin 3.2+, The assets directory has been changed from `build/intermediates/assets` to `build/intermediates/merged_assets`.

With this patch, we no longer need to copy the fonts into `android/app/src/main/assets/fonts`.

Inspired by https://github.com/facebook/react-native/pull/21408