### PR TITLE
fix failing android gradle build

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
   }
 
   dependencies {
-    classpath 'com.android.tools.build:gradle:3.1.4'
+    classpath 'com.android.tools.build:gradle:3.2.1'
   }
 }
 


### PR DESCRIPTION
**Google broke something:** 
`Over the weekend, Google removed version 2.2.0 of their gradle build tools from the standard repositories.` 
- https://help.yoyogames.com/hc/en-us/articles/360020501832
- https://issuetracker.google.com/issues/120759347#

**The current state of the repo is broken:**
```
Could not find any matches for com.android.tools.build:gradle:2.3.+ as no versions of com.android.tools.build:gradle are available.
Searched in the following locations:
    https://jcenter.bintray.com/com/android/tools/build/gradle/maven-metadata.xml
    https://jcenter.bintray.com/com/android/tools/build/gradle/
Required by:
    project :react-native-vector-icons
```

<img width="1712" alt="screen shot 2018-12-10 at 1 07 04 pm" src="https://user-images.githubusercontent.com/2933593/49761639-87d7a100-fc7c-11e8-991c-c62a394540ad.png">

**This PR is a fix.**

**Related Threads**
- https://github.com/oblador/react-native-vector-icons/issues/912
- https://github.com/oblador/react-native-vector-icons/issues/910
- https://github.com/react-native-community/react-native-image-picker/issues/1002