### PR TITLE
Fix issues with #871 when using Android Gradle Plugin 3.1

### DIFF
--- a/fonts.gradle
+++ b/fonts.gradle
@@ -25,7 +25,7 @@ gradle.projectsEvaluated {
                     "${productFlavorName}/${buildTypeName}" :
                     "${buildTypeName}"
 
-            // Create tasks for copying fonts
+            // Create task for copying fonts
             def currentFontTask = tasks.create(
                 name: "copy${targetName}IconFonts",
                 type: Copy) {

--- a/fonts.gradle
+++ b/fonts.gradle
@@ -26,32 +26,28 @@ gradle.projectsEvaluated {
                     "${buildTypeName}"
 
             // Create tasks for copying fonts
-            // compatible with Android Gradle Plugin < 3.2
-            def currentFontTask31 = tasks.create(
-                    name: "copy${targetName}IconFonts31",
-                    type: Copy) {
-                iconFontNames.each { name ->
-                    from(iconFontsDir)
-                    include(name)
-                    into("${buildDir}/intermediates/assets/${targetPath}/fonts/")
+            def currentFontTask = tasks.create(
+                name: "copy${targetName}IconFonts",
+                type: Copy) {
+
+              into("${buildDir}/intermediates")
+
+              iconFontNames.each { fontName ->
+
+                from(iconFontsDir) {
+                  include(fontName)
+                  into("assets/${targetPath}/fonts/")
                 }
+
+                from(iconFontsDir) {
+                  include(fontName)
+                  into("merged_assets/${targetPath}/merge${targetName}Assets/out/fonts/")
+                }
+              }
             }
 
-            // compatible with Android Gradle Plugin 3.2+ new asset directory
-            def currentFontTask32 = tasks.create(
-                    name: "copy${targetName}IconFonts32",
-                    type: Copy) {
-                iconFontNames.each { name ->
-                    from(iconFontsDir)
-                    include(name)
-                    into("${buildDir}/intermediates/merged_assets/${targetPath}/merge${targetName}Assets/out/fonts/")
-                }
-            }
-
-            currentFontTask31.dependsOn("merge${targetName}Resources")
-            currentFontTask31.dependsOn("merge${targetName}Assets")
-            currentFontTask32.dependsOn("merge${targetName}Resources")
-            currentFontTask32.dependsOn("merge${targetName}Assets")
+            currentFontTask.dependsOn("merge${targetName}Resources")
+            currentFontTask.dependsOn("merge${targetName}Assets")
 
             [
                 "process${flavorNameCapitalized}Armeabi-v7a${buildNameCapitalized}Resources",
@@ -62,8 +58,7 @@ gradle.projectsEvaluated {
                 Task dependentTask = tasks.findByPath(name);
 
                 if (dependentTask != null) {
-                    dependentTask.dependsOn(currentFontTask31)
-                    dependentTask.dependsOn(currentFontTask32)
+                    dependentTask.dependsOn(currentFontTask)
                 }
             }
         }

--- a/fonts.gradle
+++ b/fonts.gradle
@@ -25,22 +25,33 @@ gradle.projectsEvaluated {
                     "${productFlavorName}/${buildTypeName}" :
                     "${buildTypeName}"
 
-            // Create task for copying fonts
-            def currentFontTask = tasks.create(
-                    name: "copy${targetName}IconFonts",
+            // Create tasks for copying fonts
+            // compatible with Android Gradle Plugin < 3.2
+            def currentFontTask31 = tasks.create(
+                    name: "copy${targetName}IconFonts31",
                     type: Copy) {
                 iconFontNames.each { name ->
                     from(iconFontsDir)
                     include(name)
                     into("${buildDir}/intermediates/assets/${targetPath}/fonts/")
-                    
-                    // compatible with Android Gradle Plugin 3.2+ new asset directory
+                }
+            }
+
+            // compatible with Android Gradle Plugin 3.2+ new asset directory
+            def currentFontTask32 = tasks.create(
+                    name: "copy${targetName}IconFonts32",
+                    type: Copy) {
+                iconFontNames.each { name ->
+                    from(iconFontsDir)
+                    include(name)
                     into("${buildDir}/intermediates/merged_assets/${targetPath}/merge${targetName}Assets/out/fonts/")
                 }
             }
 
-            currentFontTask.dependsOn("merge${targetName}Resources")
-            currentFontTask.dependsOn("merge${targetName}Assets")
+            currentFontTask31.dependsOn("merge${targetName}Resources")
+            currentFontTask31.dependsOn("merge${targetName}Assets")
+            currentFontTask32.dependsOn("merge${targetName}Resources")
+            currentFontTask32.dependsOn("merge${targetName}Assets")
 
             [
                 "process${flavorNameCapitalized}Armeabi-v7a${buildNameCapitalized}Resources",
@@ -51,7 +62,8 @@ gradle.projectsEvaluated {
                 Task dependentTask = tasks.findByPath(name);
 
                 if (dependentTask != null) {
-                    dependentTask.dependsOn(currentFontTask)
+                    dependentTask.dependsOn(currentFontTask31)
+                    dependentTask.dependsOn(currentFontTask32)
                 }
             }
         }


### PR DESCRIPTION
The changes in #871 have caused issues when using older versions of the Android Gradle Plugin, i.e. 3.1.x which is used by default with React Native.  This is reported in #904 and also #661 

With 3.1.x, the current approach doesn't copy any of the font files specified.

This change creates two separate tasks, one to copy to the 3.1.X compatible path and one to copy for the 3.2.x compatible path.

I've tested with both 3.1.4 and 3.2.0 of the Android Gradle Plugin and both work with the applied change.