### PR TITLE
add android ci.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,16 @@
+version: 2
+jobs:
+  android:
+    working_directory: ~/repo
+    docker:
+      - image: reactnativecommunity/react-native-android
+    steps:
+      - checkout
+      - run: yarn install
+      - run: cd Examples/IconExplorer/android && yarn install && chmod +x gradlew && ./gradlew assembleDebug
+
+workflows:
+  version: 2
+  build_and_test:
+    jobs:
+      - android

--- a/Examples/IconExplorer/package.json
+++ b/Examples/IconExplorer/package.json
@@ -11,7 +11,7 @@
     "react": "16.5.0",
     "react-native": "0.57.1",
     "react-native-deprecated-custom-components": "^0.1.2",
-    "react-native-vector-icons": "*"
+    "react-native-vector-icons": "file::../../../"
   },
   "devDependencies": {
     "@babel/runtime": "^7.1.2",


### PR DESCRIPTION
Travis ci not friendly with docker. So I do this in circle ci.

Build log: https://circleci.com/gh/gengjiawen/react-native-vector-icons/4.