### PR TITLE
Escaping backslash ("\") at android/settings.gradle

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ These steps are optional and only needed if you want to use the `Icon.getImageSo
   include ':app'
 
   + include ':react-native-vector-icons'
-  + project(':react-native-vector-icons').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-vector-icons/android')
+  + project(':react-native-vector-icons').projectDir = new File(rootProject.projectDir, '..//node_modules//react-native-vector-icons//android')
   ```
 
 - Edit `android/app/build.gradle` (note: **app** folder) to look like this:


### PR DESCRIPTION
converted '../node_modules/react-native-vector-icons/android' to '..//node_modules//react-native-vector-icons//android' else it throws out the following error.

```
FAILURE: Build failed with an exception.

* Where:
Settings file 'F:\Projects\MongoDB Mobile Client\App\MongoDBCompanion\android\settings.gradle' line: 3

* What went wrong:
Could not compile settings file 'F:\Projects\MongoDB Mobile Client\App\MongoDBCompanion\android\settings.gradle'.
> startup failed:
  settings file 'F:\Projects\MongoDB Mobile Client\App\MongoDBCompanion\android\settings.gradle': 3: unexpected char: '\' @ line 3, column 127.
     ules\react-native-vector-icons\android')
                                   ^

  1 error
```