### PR TITLE
Update VectorIconsModule.java to fix size/spacing generated image

### DIFF
--- a/android/src/main/java/com/oblador/vectoricons/VectorIconsModule.java
+++ b/android/src/main/java/com/oblador/vectoricons/VectorIconsModule.java
@@ -67,9 +67,12 @@ public class VectorIconsModule extends ReactContextBaseJavaModule {
       Rect textBounds = new Rect();
       paint.getTextBounds(glyph, 0, glyph.length(), textBounds);
 
-      Bitmap bitmap = Bitmap.createBitmap(textBounds.width(), textBounds.height(), Bitmap.Config.ARGB_8888);
+      int offsetX = 0;
+      int offsetY = size - (int) paint.getFontMetrics().bottom;
+
+      Bitmap bitmap = Bitmap.createBitmap(size, size, Bitmap.Config.ARGB_8888);
       Canvas canvas = new Canvas(bitmap);
-      canvas.drawText(glyph, -textBounds.left, -textBounds.top, paint);
+      canvas.drawText(glyph, offsetX, offsetY, paint);
 
       try {
         fos = new FileOutputStream(cacheFile);


### PR DESCRIPTION
Android change: Instead of generating an image with getTextBounds (which will create an image according to the character size), it is using the passed size + getFontMetrics to get spacing as well. 
The image will be the same as the imported svg in the font, when you use the Icon class in js and when you generate image for iOS.