### PR TITLE
Export generated flow type enum for iconsets

### DIFF
--- a/bin/generate-flow.js
+++ b/bin/generate-flow.js
@@ -25,7 +25,7 @@ for (let i = 0; i < icons.length; i += 1) {
 
 import type { Icon } from './index';
 
-type ${icon}Glyphs = '${names}';
+export type ${icon}Glyphs = '${names}';
 
 declare export default Class<Icon<${icon}Glyphs>>;
 `;


### PR DESCRIPTION
In my case, I have some wrappers for `Icon`; it'd be really nice to be able to re-use the available icon names there.

This change allows me to `import Ionicons, {type IoniconsGlyphs} from 'react-native-vector-icons/Ionicons'`, and automatically stay up to date with icon changes from this package.