### PR TITLE
FontAwesome 5 fix for Android

### DIFF
--- a/lib/create-icon-set-from-fontawesome5.js
+++ b/lib/create-icon-set-from-fontawesome5.js
@@ -1,3 +1,4 @@
+import { Platform } from './react-native';
 import createMultiStyleIconSet from './create-multi-style-icon-set';
 
 const FA5Style = {
@@ -38,9 +39,12 @@ function createFA5iconSet(glyphMap, metadata = {}, pro = false) {
     return {
       fontFamily: `${family}-${styleName}`,
       fontFile,
-      fontStyle: {
-        fontWeight,
-      },
+      fontStyle: Platform.select({
+        ios: {
+          fontWeight,
+        },
+        default: {},
+      }),
       glyphMap,
     };
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-vector-icons",
-  "version": "6.4.1",
+  "version": "6.4.2",
   "description": "Customizable Icons for React Native with support for NavBar/TabBar/ToolbarAndroid, image source and full styling.",
   "main": "dist/index.js",
   "bin": {


### PR DESCRIPTION
Only using additional style on iOS since it breaks on non-iOS platforms (at least Android but others also seems to use font file instead fo font family when selecting fonts). Fixes #964.

Also updates package.json for new release.