### PR TITLE
make FA5 brand icons work on Android 

### DIFF
--- a/lib/create-icon-set-from-fontawesome5.js
+++ b/lib/create-icon-set-from-fontawesome5.js
@@ -29,7 +29,8 @@ function createFA5iconSet(glyphMap, metadata = {}, pro = false) {
     return metadata[family].indexOf(glyph) !== -1;
   }
 
-  function createFontAwesomeStyle(styleName, fontWeight, family = fontFamily) {
+  function createFontAwesomeStyle(style, fontWeight, family = fontFamily) {
+    let styleName = style;
     let fontFile = `FontAwesome5_${pro ? `Pro_${styleName}` : styleName}.ttf`;
 
     if (styleName === 'Brands') {

--- a/lib/create-icon-set-from-fontawesome5.js
+++ b/lib/create-icon-set-from-fontawesome5.js
@@ -50,7 +50,7 @@ function createFA5iconSet(glyphMap, metadata = {}, pro = false) {
   }
 
   const brandIcons = createFontAwesomeStyle(
-    'Regular',
+    Platform.OS === 'android' ? 'Brands' : 'Regular',
     '400',
     'FontAwesome5Brands'
   );

--- a/lib/create-icon-set-from-fontawesome5.js
+++ b/lib/create-icon-set-from-fontawesome5.js
@@ -33,6 +33,7 @@ function createFA5iconSet(glyphMap, metadata = {}, pro = false) {
     let fontFile = `FontAwesome5_${pro ? `Pro_${styleName}` : styleName}.ttf`;
 
     if (styleName === 'Brands') {
+      styleName = 'Regular';
       fontFile = 'FontAwesome5_Brands.ttf';
     }
 
@@ -50,7 +51,7 @@ function createFA5iconSet(glyphMap, metadata = {}, pro = false) {
   }
 
   const brandIcons = createFontAwesomeStyle(
-    Platform.OS === 'android' ? 'Brands' : 'Regular',
+    'Brands',
     '400',
     'FontAwesome5Brands'
   );


### PR DESCRIPTION
Use `Brands` for Android and `Regular` for rest. 

Closes #983. 