### PR TITLE
Add a workaround for the new asset directory

### DIFF
--- a/fonts.gradle
+++ b/fonts.gradle
@@ -25,9 +25,16 @@ gradle.projectsEvaluated {
                 into("assets/${targetPath}/fonts/")
               }
 
+              // Workaround for Android Gradle Plugin 3.2+ new asset directory
               from(iconFontsDir) {
                 include(fontName)
                 into("merged_assets/${variant.name}/merge${targetName}Assets/out/fonts/")
+              }
+
+              // Workaround for Android Gradle Plugin 3.4+ new asset directory
+              from(iconFontsDir) {
+                include(fontName)
+                into("merged_assets/${variant.name}/out/fonts/")
               }
             }
         }


### PR DESCRIPTION
Starting from Gradle Plugin 3.4+, the merged assets directory changed once again stripping out the target name.