### PR TITLE
fix: avoid exporting via unreliable path

### DIFF
--- a/lib/react-native.web.js
+++ b/lib/react-native.web.js
@@ -1,3 +1,3 @@
 /* eslint-disable import/no-unresolved */
 
-export * from 'react-native-web/dist/cjs';
+export * from 'react-native-web';


### PR DESCRIPTION
Exporting `react-native-web` via path causes StyleSheet to be instantiated twice and hence creates unreliable styles. See: https://github.com/necolas/react-native-web/issues/1367