### PR TITLE
feat: add `react-native.config.js` for RN 0.60 compat

### DIFF
--- a/react-native.config.js
+++ b/react-native.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  dependency: {
+    assets: ['Fonts'],
+  },
+};


### PR DESCRIPTION
React Native 0.60 is right behind the corner and it comes with latest CLI that now expects the RN config to live in `react-native.config.js`, while `"rnpm"` gets deprecated. Here's the docs on [dependencies](https://github.com/react-native-community/cli/blob/master/docs/dependencies.md) which in CLI terms are libraries like this one.

I'm not removing `"rnpm"` entry for now, since I'm not sure if you plan to support multiple RN versions with a single version of vector-icons) and they can happily live next to each other. Feel free to remove it later though :)