### PR TITLE
Export glyphMap from icomoon icon set helper

### DIFF
--- a/lib/create-icon-set-from-icomoon.js
+++ b/lib/create-icon-set-from-icomoon.js
@@ -1,11 +1,12 @@
 import createIconSet from './create-icon-set';
 
+export const glyphMap = {};
+
 export default function createIconSetFromIcoMoon(
   config,
   fontFamilyArg,
   fontFile
 ) {
-  const glyphMap = {};
   config.icons.forEach(icon => {
     icon.properties.name.split(/\s*,\s*/g).forEach(name => {
       glyphMap[name] = icon.properties.code;


### PR DESCRIPTION
This PR exports icomoon's glyph map, so that we can fall back to another font family if required ([#1034](https://github.com/oblador/react-native-vector-icons/issues/1034))