### PR TITLE
Fixes spelling of antdesign backward icon

### DIFF
--- a/glyphmaps/AntDesign.json
+++ b/glyphmaps/AntDesign.json
@@ -2,7 +2,7 @@
   "stepforward": 58880,
   "stepbackward": 58881,
   "forward": 58882,
-  "banckward": 58883,
+  "backward": 58883,
   "caretright": 58884,
   "caretleft": 58885,
   "caretdown": 58886,


### PR DESCRIPTION
It is currently `banckward` which seems incorrect