### PR TITLE
Improvement: removed depcreated rnpm

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,11 +60,6 @@
     "url": "git://github.com/oblador/react-native-vector-icons.git"
   },
   "license": "MIT",
-  "rnpm": {
-    "assets": [
-      "Fonts"
-    ]
-  },
   "dependencies": {
     "lodash": "^4.17.15",
     "prop-types": "^15.7.2",


### PR DESCRIPTION
**Problem:**
react-native show the warning of using deprecated `rnpm` command in package.json. 

**What has been changed:**
This project already uses react-native.config.js, so `rnpm` was removed from package.json