### PR TITLE
Update ToolbarAndroid to use community version; removed from RN 0.61

### DIFF
--- a/lib/toolbar-android.js
+++ b/lib/toolbar-android.js
@@ -3,7 +3,7 @@ import isEqual from 'lodash/isEqual';
 import pick from 'lodash/pick';
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import { ToolbarAndroid } from './react-native';
+import ToolbarAndroid from '@react-native-community/toolbar-android';
 
 const ICON_PROP_NAMES = ['iconSize', 'iconColor', 'titleColor'];
 const LOGO_ICON_PROP_NAMES = [...ICON_PROP_NAMES, 'logoName'];


### PR DESCRIPTION
As discussed here: https://github.com/facebook/react-native/issues/26591 RN 0.61 removed the Android Toolbar. A community version was created here: https://www.npmjs.com/package/@react-native-community/toolbar-android

This is currently throwing an error when trying to use vector-icons with react-native-web v0.12.