### PR TITLE
Add getImageSourceSync method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ bower_components
 # Xcode
 
 xcuserdata
+
+.DS_Store

--- a/AntDesign.js
+++ b/AntDesign.js
@@ -15,5 +15,5 @@ export const {
   TabBarItemIOS,
   ToolbarAndroid,
   getImageSource,
+  getImageSourceSync,
 } = iconSet;
-

--- a/Entypo.js
+++ b/Entypo.js
@@ -15,4 +15,5 @@ export const {
   TabBarItemIOS,
   ToolbarAndroid,
   getImageSource,
+  getImageSourceSync,
 } = iconSet;

--- a/EvilIcons.js
+++ b/EvilIcons.js
@@ -15,4 +15,5 @@ export const {
   TabBarItemIOS,
   ToolbarAndroid,
   getImageSource,
+  getImageSourceSync,
 } = iconSet;

--- a/Examples/IconExplorer/ios/IconExplorer.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Examples/IconExplorer/ios/IconExplorer.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Examples/IconExplorer/package.json
+++ b/Examples/IconExplorer/package.json
@@ -6,15 +6,17 @@
     "android": "react-native run-android",
     "ios": "react-native run-ios",
     "start": "react-native start",
+    "postinstall": "pwd && ./scripts/postinstall.sh",
     "test": "jest"
   },
   "dependencies": {
+    "@react-native-community/toolbar-android": "^0.1.0-rc.1",
     "ramda": "^0.26.1",
     "react": "16.9.0",
     "react-native": "0.61.5",
     "react-native-gesture-handler": "^1.5.1",
     "react-native-screens": "^2.0.0-alpha.12",
-    "react-native-vector-icons": "*",
+    "react-native-vector-icons": "file:../../",
     "react-navigation": "^4.0.10",
     "react-navigation-stack": "^1.10.3"
   },

--- a/Examples/IconExplorer/scripts/postinstall.sh
+++ b/Examples/IconExplorer/scripts/postinstall.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+rm -rf node_modules/react-native-vector-icons/Examples
+rm -rf node_modules/react-native-vector-icons/node_modules

--- a/Examples/IconExplorer/src/IconSetList.js
+++ b/Examples/IconExplorer/src/IconSetList.js
@@ -2,8 +2,7 @@ import React, { PureComponent } from 'react';
 import FontAwesome from 'react-native-vector-icons/FontAwesome';
 import {
   Alert,
-  Keyboard,
-  Platform,
+  Image,
   SectionList,
   StyleSheet,
   Text,
@@ -11,7 +10,6 @@ import {
   View,
 } from './react-native';
 
-import IconList from './IconList';
 import ICON_SETS from './icon-sets';
 
 const BUTTONS = [
@@ -83,6 +81,18 @@ const INLINE = [
   },
 ];
 
+const SYNCHROUNOUS = [
+  {
+    name: 'synchronous',
+    children: (
+      <Image
+        source={FontAwesome.getImageSourceSync('check', 40, 'green')}
+        style={{ height: 40, width: 40 }}
+      />
+    ),
+  },
+];
+
 const styles = StyleSheet.create({
   sectionHeader: {
     paddingVertical: 5,
@@ -136,9 +146,7 @@ const renderButton = ({ item }) => (
   </View>
 );
 
-const renderInline = ({ item }) => (
-  <View style={styles.row}>{item.children}</View>
-);
+const renderRow = ({ item }) => <View style={styles.row}>{item.children}</View>;
 
 const renderStyling = ({ item }) => (
   <View style={styles.row}>
@@ -153,7 +161,8 @@ export default class IconSetsList extends PureComponent {
     sections: [
       { title: 'ICON SETS', data: ICON_SETS },
       { title: 'BUTTONS', data: BUTTONS, renderItem: renderButton },
-      { title: 'INLINE', data: INLINE, renderItem: renderInline },
+      { title: 'INLINE', data: INLINE, renderItem: renderRow },
+      { title: 'SYNCHROUNOUS', data: SYNCHROUNOUS, renderItem: renderRow },
       { title: 'STYLING', data: STYLING, renderItem: renderStyling },
     ],
   };

--- a/Examples/IconExplorer/yarn.lock
+++ b/Examples/IconExplorer/yarn.lock
@@ -931,6 +931,11 @@
     wcwidth "^1.0.1"
     ws "^1.1.0"
 
+"@react-native-community/toolbar-android@^0.1.0-rc.1":
+  version "0.1.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@react-native-community/toolbar-android/-/toolbar-android-0.1.0-rc.1.tgz#5cd8451295628d6a5f87b2e6c162a94c0124de8d"
+  integrity sha512-j/CjkM5aT9N3tOF9yPxXoS9J3g/99FxnHkWTz9B+oXhp8RbJZPdpIIvNaYGUlKTBoNf66lmQrPvgnjbTvfEdLg==
+
 "@react-navigation/core@^3.5.1":
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/@react-navigation/core/-/core-3.5.1.tgz#7a2339fca3496979305fb3a8ab88c2ca8d8c214d"
@@ -982,6 +987,11 @@
   integrity sha512-yGeB2dHEdvxjP0y4UbRtQaSkXJ9649fYCmIdRoul5kfAoGCwxuCbMhag0k3RPfnuh9kPGm8x89btcfDEXdVWGw==
   dependencies:
     "@babel/types" "^7.3.0"
+
+"@types/color-name@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
+  integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
 
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0":
   version "2.0.1"
@@ -1140,12 +1150,25 @@ ansi-regex@^4.0.0, ansi-regex@^4.1.0:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.0.tgz#8b9f8f08cf1acb843756a839ca8c7e3168c51997"
   integrity sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==
 
+ansi-regex@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.0.tgz#388539f55179bf39339c81af30a654d69f87cb75"
+  integrity sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==
+
 ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
   integrity sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==
   dependencies:
     color-convert "^1.9.0"
+
+ansi-styles@^4.0.0:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.2.1.tgz#90ae75c424d008d2624c5bf29ead3177ebfcf359"
+  integrity sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==
+  dependencies:
+    "@types/color-name" "^1.1.1"
+    color-convert "^2.0.1"
 
 ansi-wrap@0.1.0, ansi-wrap@^0.1.0:
   version "0.1.0"
@@ -1638,6 +1661,15 @@ cliui@^5.0.0:
     strip-ansi "^5.2.0"
     wrap-ansi "^5.1.0"
 
+cliui@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-6.0.0.tgz#511d702c0c4e41ca156d7d0e96021f23e13225b1"
+  integrity sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==
+  dependencies:
+    string-width "^4.2.0"
+    strip-ansi "^6.0.0"
+    wrap-ansi "^6.2.0"
+
 clone@^1.0.2:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
@@ -1668,10 +1700,22 @@ color-convert@^1.9.0:
   dependencies:
     color-name "1.1.3"
 
+color-convert@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-2.0.1.tgz#72d3a68d598c9bdb3af2ad1e84f21d896abd4de3"
+  integrity sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==
+  dependencies:
+    color-name "~1.1.4"
+
 color-name@1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
+
+color-name@~1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
+  integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
 color-support@^1.1.3:
   version "1.1.3"
@@ -2015,6 +2059,11 @@ emoji-regex@^7.0.1:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-7.0.3.tgz#933a04052860c85e83c122479c4748a8e4c72156"
   integrity sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==
+
+emoji-regex@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
+  integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
 
 encodeurl@~1.0.2:
   version "1.0.2"
@@ -2876,6 +2925,11 @@ is-fullwidth-code-point@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f"
   integrity sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=
 
+is-fullwidth-code-point@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz#f116f8064fe90b3f7844a38997c0b75051269f1d"
+  integrity sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==
+
 is-generator-fn@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-generator-fn/-/is-generator-fn-2.1.0.tgz#7d140adc389aaf3011a8f2a2a4cfa6faadffb118"
@@ -3632,7 +3686,7 @@ lodash.throttle@^4.1.1:
   resolved "https://registry.yarnpkg.com/lodash.throttle/-/lodash.throttle-4.1.1.tgz#c23e91b710242ac70c37f1e1cda9274cc39bf2f4"
   integrity sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ=
 
-lodash@^4.0.0, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.5, lodash@^4.3.0:
+lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.5, lodash@^4.3.0:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
@@ -4850,14 +4904,12 @@ react-native-screens@^2.0.0-alpha.12:
   dependencies:
     debounce "^1.2.0"
 
-react-native-vector-icons@*:
+"react-native-vector-icons@file:../..":
   version "6.6.0"
-  resolved "https://registry.yarnpkg.com/react-native-vector-icons/-/react-native-vector-icons-6.6.0.tgz#66cf004918eb05d90778d64bd42077c1800d481b"
-  integrity sha512-MImKVx8JEvVVBnaShMr7/yTX4Y062JZMupht1T+IEgbqBj4aQeQ1z2SH4VHWKNtWtppk4kz9gYyUiMWqx6tNSw==
   dependencies:
-    lodash "^4.0.0"
-    prop-types "^15.6.2"
-    yargs "^13.2.2"
+    lodash "^4.17.15"
+    prop-types "^15.7.2"
+    yargs "^15.0.2"
 
 react-native@0.61.5:
   version "0.61.5"
@@ -5590,6 +5642,15 @@ string-width@^3.0.0, string-width@^3.1.0:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^5.1.0"
 
+string-width@^4.1.0, string-width@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.0.tgz#952182c46cc7b2c313d1596e623992bd163b72b5"
+  integrity sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.0"
+
 string.prototype.trimleft@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/string.prototype.trimleft/-/string.prototype.trimleft-2.1.0.tgz#6cc47f0d7eb8d62b0f3701611715a3954591d634"
@@ -5633,6 +5694,13 @@ strip-ansi@^5.0.0, strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
+
+strip-ansi@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.0.tgz#0b1571dd7669ccd4f3e06e14ef1eed26225ae532"
+  integrity sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==
+  dependencies:
+    ansi-regex "^5.0.0"
 
 strip-bom@^3.0.0:
   version "3.0.0"
@@ -6092,6 +6160,15 @@ wrap-ansi@^5.1.0:
     string-width "^3.0.0"
     strip-ansi "^5.0.0"
 
+wrap-ansi@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
+  integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
@@ -6215,6 +6292,14 @@ yargs-parser@^13.1.1:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
 
+yargs-parser@^16.1.0:
+  version "16.1.0"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-16.1.0.tgz#73747d53ae187e7b8dbe333f95714c76ea00ecf1"
+  integrity sha512-H/V41UNZQPkUMIT5h5hiwg4QKIY1RPvoBV4XcjUbRM8Bk2oKqqyZ0DIEbTFZB0XjbtSPG8SAa/0DxCQmiRgzKg==
+  dependencies:
+    camelcase "^5.0.0"
+    decamelize "^1.2.0"
+
 yargs-parser@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-7.0.0.tgz#8d0ac42f16ea55debd332caf4c4038b3e3f5dfd9"
@@ -6240,7 +6325,7 @@ yargs@^12.0.5:
     y18n "^3.2.1 || ^4.0.0"
     yargs-parser "^11.1.1"
 
-yargs@^13.2.2, yargs@^13.3.0:
+yargs@^13.3.0:
   version "13.3.0"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-13.3.0.tgz#4c657a55e07e5f2cf947f8a366567c04a0dedc83"
   integrity sha512-2eehun/8ALW8TLoIl7MVaRUrg+yCnenu8B4kBlRxj3GJGDKU1Og7sMXPNm1BYyM1DOJmTZ4YeN/Nwxv+8XJsUA==
@@ -6255,6 +6340,23 @@ yargs@^13.2.2, yargs@^13.3.0:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^13.1.1"
+
+yargs@^15.0.2:
+  version "15.1.0"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-15.1.0.tgz#e111381f5830e863a89550bd4b136bb6a5f37219"
+  integrity sha512-T39FNN1b6hCW4SOIk1XyTOWxtXdcen0t+XYrysQmChzSipvhBO8Bj0nK1ozAasdk24dNWuMZvr4k24nz+8HHLg==
+  dependencies:
+    cliui "^6.0.0"
+    decamelize "^1.2.0"
+    find-up "^4.1.0"
+    get-caller-file "^2.0.1"
+    require-directory "^2.1.1"
+    require-main-filename "^2.0.0"
+    set-blocking "^2.0.0"
+    string-width "^4.2.0"
+    which-module "^2.0.0"
+    y18n "^4.0.0"
+    yargs-parser "^16.1.0"
 
 yargs@^9.0.0:
   version "9.0.1"

--- a/Feather.js
+++ b/Feather.js
@@ -15,4 +15,5 @@ export const {
   TabBarItemIOS,
   ToolbarAndroid,
   getImageSource,
+  getImageSourceSync,
 } = iconSet;

--- a/FontAwesome.js
+++ b/FontAwesome.js
@@ -15,5 +15,5 @@ export const {
   TabBarItemIOS,
   ToolbarAndroid,
   getImageSource,
+  getImageSourceSync,
 } = iconSet;
-

--- a/FontAwesome5.js
+++ b/FontAwesome5.js
@@ -19,4 +19,5 @@ export const {
   TabBarItemIOS,
   ToolbarAndroid,
   getImageSource,
+  getImageSourceSync,
 } = iconSet;

--- a/FontAwesome5Pro.js
+++ b/FontAwesome5Pro.js
@@ -19,4 +19,5 @@ export const {
   TabBarItemIOS,
   ToolbarAndroid,
   getImageSource,
+  getImageSourceSync,
 } = iconSet;

--- a/Fontisto.js
+++ b/Fontisto.js
@@ -15,5 +15,5 @@ export const {
   TabBarItemIOS,
   ToolbarAndroid,
   getImageSource,
+  getImageSourceSync,
 } = iconSet;
-

--- a/Foundation.js
+++ b/Foundation.js
@@ -15,5 +15,5 @@ export const {
   TabBarItemIOS,
   ToolbarAndroid,
   getImageSource,
+  getImageSourceSync,
 } = iconSet;
-

--- a/Ionicons.js
+++ b/Ionicons.js
@@ -15,5 +15,5 @@ export const {
   TabBarItemIOS,
   ToolbarAndroid,
   getImageSource,
+  getImageSourceSync,
 } = iconSet;
-

--- a/MaterialCommunityIcons.js
+++ b/MaterialCommunityIcons.js
@@ -15,5 +15,5 @@ export const {
   TabBarItemIOS,
   ToolbarAndroid,
   getImageSource,
+  getImageSourceSync,
 } = iconSet;
-

--- a/MaterialIcons.js
+++ b/MaterialIcons.js
@@ -15,5 +15,5 @@ export const {
   TabBarItemIOS,
   ToolbarAndroid,
   getImageSource,
+  getImageSourceSync,
 } = iconSet;
-

--- a/Octicons.js
+++ b/Octicons.js
@@ -15,4 +15,5 @@ export const {
   TabBarItemIOS,
   ToolbarAndroid,
   getImageSource,
+  getImageSourceSync,
 } = iconSet;

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ If you want to use any of the bundled icons, you need to add the icon fonts to y
 
 _Note: you need to recompile your project after adding new fonts, also ensure that they also appear under **Copy Bundle Resources** in **Build Phases**._
 
-If you want to use the TabBar/NavigatorIOS integration or use `getImageSource`, then you need to add `RNVectorIcons.xcodeproj` to **Libraries** and add `libRNVectorIcons.a` to **Link Binary With Libraries** under **Build Phases**. [More info and screenshots about how to do this is available in the React Native documentation](http://facebook.github.io/react-native/docs/linking-libraries-ios.html#content).
+If you want to use the TabBar/NavigatorIOS integration or use `getImageSource`/`getImageSourceSync`, then you need to add `RNVectorIcons.xcodeproj` to **Libraries** and add `libRNVectorIcons.a` to **Link Binary With Libraries** under **Build Phases**. [More info and screenshots about how to do this is available in the React Native documentation](http://facebook.github.io/react-native/docs/linking-libraries-ios.html#content).
 
 #### Option: With `react-native link`
 
@@ -193,8 +193,6 @@ These steps are optional and only needed if you want to use the `Icon.getImageSo
   }
   ```
 
-_Note: If you're using React Native (Android) <= 0.17, [follow this instructions](https://github.com/oblador/react-native-vector-icons/blob/2fe5b97afa849652215e3258189e8ca3ea775c53/README.md#integrating-library-for-getimagesource-support)_
-
 #### Option: With `rnpm`
 
 `$ react-native link`
@@ -284,6 +282,7 @@ Any [Text property](http://facebook.github.io/react-native/docs/text.html) and t
 | -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **`getFontFamily`**  | Returns the font family that is currently used to retrieve icons as text. Usage: `const fontFamily = Icon.getFontFamily()`                                                                |
 | **`getImageSource`** | Returns a promise that resolving to the source of a bitmap version of the icon for use with `Image` component et al. Usage: `const source = await Icon.getImageSource(name, size, color)` |
+| **`getImageSourceSync`** | Same as `getImageSource` but synchronous. Usage: `const source = Icon.getImageSourceSync(name, size, color)` |
 | **`getRawGlyphMap`** | Returns the raw glyph map of the icon set. Usage: `const glyphMap = Icon.getRawGlyphMap()`                                                                                                |
 | **`hasIcon`**        | Checks if the name is valid in current icon set. Usage: `const isNameValid = Icon.hasIcon(name)`                                                                                          |
 
@@ -351,9 +350,11 @@ Any [`Text`](http://facebook.github.io/react-native/docs/text.html), [`Touchable
 
 Convenient way to plug this in into other components that rely on bitmap images rather than scalable vector icons. Takes the arguments `name`, `size` and `color` as described above.
 
-```
+```js
 Icon.getImageSource('user', 20, 'red').then((source) => this.setState({ userIcon: source }));
 ```
+
+Alternatively you may use the synchronous method `Icon.getImageSourceSync` to avoid rendering glitches. Keep in mind that this method is blocking and might incur performance penalties. Subsequent calls will use cache however. 
 
 For a complete example check out the `TabBarExample` project.
 
@@ -409,7 +410,8 @@ All static methods from `Icon` is supported by multi-styled fonts.
 | Prop                   | Description                                                                                                                                                                                      |
 | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | **`getFontFamily`**    | Returns the font family that is currently used to retrieve icons as text. Usage: `const fontFamily = Icon.getFontFamily(style)`                                                                  |
-| **`getImageSource`**   | Returns a promise that resolving to the source of a bitmap version of the icon for use with `Image` component et al. Usage: `const source = await Icon.getImageSource(name, size, color, style)` |
+| **`getImageSource`**   | Returns a promise that resolving to the source of a bitmap version of the icon for use with `Image` component et al. Usage: `const source = await Icon.getImageSource(name, size, color)` |
+| **`getImageSourceSync`**   | Same as `getImageSource` but synchronous. Usage: `const source = Icon.getImageSourceSync(name, size, color)` |
 | **`getRawGlyphMap`**   | Returns the raw glyph map of the icon set. Usage: `const glyphMap = Icon.getRawGlyphMap(style)`                                                                                                  |
 | **`hasIcon`**          | Checks if the name is valid in current icon set. Usage: `const isNameValid = Icon.hasIcon(name, style)`                                                                                          |
 | **`getStyledIconSet`** | Use this to get a `Icon` component for a single style. Usage. `const StyledIcon = Icon.getStyledIconSet(style)`                                                                                  |

--- a/RNVectorIcons.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/RNVectorIcons.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/RNVectorIconsManager/RNVectorIconsManager.h
+++ b/RNVectorIconsManager/RNVectorIconsManager.h
@@ -17,6 +17,12 @@
 #import "RCTLog.h"
 #endif
 
+FOUNDATION_EXPORT NSString *const RNVIErrorDomain;
+
+enum {
+  RNVIGenericError = 1000,
+};
+
 @interface RNVectorIconsManager : NSObject <RCTBridgeModule>
 
 - (NSString *)hexStringFromColor:(UIColor *)color;

--- a/SimpleLineIcons.js
+++ b/SimpleLineIcons.js
@@ -15,5 +15,5 @@ export const {
   TabBarItemIOS,
   ToolbarAndroid,
   getImageSource,
+  getImageSourceSync,
 } = iconSet;
-

--- a/Zocial.js
+++ b/Zocial.js
@@ -15,5 +15,5 @@ export const {
   TabBarItemIOS,
   ToolbarAndroid,
   getImageSource,
+  getImageSourceSync,
 } = iconSet;
-

--- a/android/src/main/java/com/oblador/vectoricons/VectorIconsModule.java
+++ b/android/src/main/java/com/oblador/vectoricons/VectorIconsModule.java
@@ -14,7 +14,7 @@ import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
-import com.facebook.react.bridge.Callback;
+import com.facebook.react.bridge.Promise;
 import com.facebook.react.views.text.ReactFontManager;
 
 import java.io.File;
@@ -30,6 +30,10 @@ public class VectorIconsModule extends ReactContextBaseJavaModule {
 
   public static final String REACT_CLASS = "RNVectorIconsModule";
 
+  @interface Errors {
+    String E_UNKNOWN_ERROR = "E_UNKNOWN_ERROR";
+  }
+
   @Override
   public String getName() {
     return REACT_CLASS;
@@ -39,8 +43,7 @@ public class VectorIconsModule extends ReactContextBaseJavaModule {
     super(reactContext);
   }
 
-  @ReactMethod
-  public void getImageForFont(String fontFamily, String glyph, Integer fontSize, Integer color, Callback callback) {
+  protected String createGlyphImagePath(String fontFamily, String glyph, Integer fontSize, Integer color) throws java.io.IOException, FileNotFoundException {
     Context context = getReactApplicationContext();
     File cacheFolder = context.getCacheDir();
     String cacheFolderPath = cacheFolder.getAbsolutePath() + "/";
@@ -55,50 +58,64 @@ public class VectorIconsModule extends ReactContextBaseJavaModule {
     File cacheFile = new File(cacheFilePath);
 
     if(cacheFile.exists()) {
-      callback.invoke(null, cacheFileUrl);
-    } else {
-      FileOutputStream fos = null;
-      Typeface typeface = ReactFontManager.getInstance().getTypeface(fontFamily, 0, context.getAssets());
-      Paint paint = new Paint();
-      paint.setTypeface(typeface);
-      paint.setColor(color);
-      paint.setTextSize(size);
-      paint.setAntiAlias(true);
-      Rect textBounds = new Rect();
-      paint.getTextBounds(glyph, 0, glyph.length(), textBounds);
+      return cacheFileUrl;
+    }
 
-      int offsetX = 0;
-      int offsetY = size - (int) paint.getFontMetrics().bottom;
+    FileOutputStream fos = null;
+    Typeface typeface = ReactFontManager.getInstance().getTypeface(fontFamily, 0, context.getAssets());
+    Paint paint = new Paint();
+    paint.setTypeface(typeface);
+    paint.setColor(color);
+    paint.setTextSize(size);
+    paint.setAntiAlias(true);
+    Rect textBounds = new Rect();
+    paint.getTextBounds(glyph, 0, glyph.length(), textBounds);
 
-      Bitmap bitmap = Bitmap.createBitmap(size, size, Bitmap.Config.ARGB_8888);
-      Canvas canvas = new Canvas(bitmap);
-      canvas.drawText(glyph, offsetX, offsetY, paint);
+    int offsetX = 0;
+    int offsetY = size - (int) paint.getFontMetrics().bottom;
 
-      try {
-        fos = new FileOutputStream(cacheFile);
-        bitmap.compress(CompressFormat.PNG, 100, fos);
-        fos.flush();
-        fos.close();
-        fos = null;
+    Bitmap bitmap = Bitmap.createBitmap(size, size, Bitmap.Config.ARGB_8888);
+    Canvas canvas = new Canvas(bitmap);
+    canvas.drawText(glyph, offsetX, offsetY, paint);
 
-        callback.invoke(null, cacheFileUrl);
-      } catch (FileNotFoundException e) {
-        callback.invoke(e.getMessage());
-      } catch (IOException e) {
-        callback.invoke(e.getMessage());
-      }
-      finally {
-        if (fos != null) {
-          try {
-            fos.close();
-            fos = null;
-          }
-          catch (IOException e) {
-            e.printStackTrace();
-          }
+    try {
+      fos = new FileOutputStream(cacheFile);
+      bitmap.compress(CompressFormat.PNG, 100, fos);
+      fos.flush();
+      fos.close();
+      fos = null;
+
+      return cacheFileUrl;
+    }
+    finally {
+      if (fos != null) {
+        try {
+          fos.close();
+          fos = null;
+        }
+        catch (IOException e) {
+          e.printStackTrace();
         }
       }
     }
   }
 
+  @ReactMethod
+  public void getImageForFont(String fontFamily, String glyph, Integer fontSize, Integer color, final Promise promise) {
+    try {
+      String imagePath = createGlyphImagePath(fontFamily, glyph, fontSize, color);
+      promise.resolve(imagePath);
+    } catch (Throwable fail) {
+      promise.reject(Errors.E_UNKNOWN_ERROR, fail);
+    }
+  }
+
+  @ReactMethod(isBlockingSynchronousMethod = true)
+  public String getImageForFontSync(String fontFamily, String glyph, Integer fontSize, Integer color) {
+    try {
+      return createGlyphImagePath(fontFamily, glyph, fontSize, color);
+    } catch (Throwable fail) {
+      return null;
+    }
+  }
 }

--- a/index.js.flow
+++ b/index.js.flow
@@ -77,6 +77,11 @@ declare class Icon<Glyphs: string> extends PureComponent<IconProps<Glyphs>> {
     size?: number,
     color?: Color
   ): Promise<ImageSource>;
+  static getImageSourceSync(
+    name: Glyphs,
+    size?: number,
+    color?: Color
+  ): ImageSource;
   static getRawGlyphMap(): { [name: Glyphs]: number };
   static hasIcon(name: string): boolean;
   static loadFont(file?: string): Promise<void>;

--- a/lib/create-icon-set.js
+++ b/lib/create-icon-set.js
@@ -9,6 +9,7 @@ import {
 } from './react-native';
 
 import ensureNativeModuleAvailable from './ensure-native-module-available';
+import createIconSourceCache from './create-icon-source-cache';
 import createIconButtonComponent from './icon-button';
 import createTabBarItemIOSComponent from './tab-bar-item-ios';
 import createToolbarAndroidComponent from './toolbar-android';
@@ -97,63 +98,84 @@ export default function createIconSet(
     }
   }
 
-  const imageSourceCache = {};
+  const imageSourceCache = createIconSourceCache();
 
-  function getImageSource(
+  function resolveGlyph(name) {
+    const glyph = glyphMap[name] || '?';
+    if (typeof glyph === 'number') {
+      return String.fromCharCode(glyph);
+    }
+    return glyph;
+  }
+
+  function getImageSourceSync(
     name,
     size = DEFAULT_ICON_SIZE,
     color = DEFAULT_ICON_COLOR
   ) {
     ensureNativeModuleAvailable();
 
-    let glyph = glyphMap[name] || '?';
-    if (typeof glyph === 'number') {
-      glyph = String.fromCharCode(glyph);
-    }
-
+    const glyph = resolveGlyph(name);
     const processedColor = processColor(color);
     const cacheKey = `${glyph}:${size}:${processedColor}`;
-    const scale = PixelRatio.get();
 
-    return new Promise((resolve, reject) => {
-      const cached = imageSourceCache[cacheKey];
-      if (typeof cached !== 'undefined') {
-        if (!cached || cached instanceof Error) {
-          reject(cached);
-        } else {
-          resolve({ uri: cached, scale });
-        }
-      } else {
-        NativeIconAPI.getImageForFont(
-          fontReference,
-          glyph,
-          size,
-          processedColor,
-          (err, image) => {
-            const error = typeof err === 'string' ? new Error(err) : err;
-            imageSourceCache[cacheKey] = image || error || false;
-            if (!error && image) {
-              resolve({ uri: image, scale });
-            } else {
-              reject(error);
-            }
-          }
-        );
-      }
-    });
+    if (imageSourceCache.has(cacheKey)) {
+      return imageSourceCache.get(cacheKey);
+    }
+    try {
+      const imagePath = NativeIconAPI.getImageForFontSync(
+        fontReference,
+        glyph,
+        size,
+        processedColor
+      );
+      const value = { uri: imagePath, scale: PixelRatio.get() };
+      imageSourceCache.setValue(cacheKey, value);
+      return value;
+    } catch (error) {
+      imageSourceCache.setError(cacheKey, error);
+      throw error;
+    }
   }
 
-  function loadFont(file = fontFile) {
+  async function getImageSource(
+    name,
+    size = DEFAULT_ICON_SIZE,
+    color = DEFAULT_ICON_COLOR
+  ) {
+    ensureNativeModuleAvailable();
+
+    const glyph = resolveGlyph(name);
+    const processedColor = processColor(color);
+    const cacheKey = `${glyph}:${size}:${processedColor}`;
+
+    if (imageSourceCache.has(cacheKey)) {
+      return imageSourceCache.get(cacheKey);
+    }
+    try {
+      const imagePath = await NativeIconAPI.getImageForFont(
+        fontReference,
+        glyph,
+        size,
+        processedColor
+      );
+      const value = { uri: imagePath, scale: PixelRatio.get() };
+      imageSourceCache.setValue(cacheKey, value);
+      return value;
+    } catch (error) {
+      imageSourceCache.setError(cacheKey, error);
+      throw error;
+    }
+  }
+
+  async function loadFont(file = fontFile) {
     if (Platform.OS === 'ios') {
       ensureNativeModuleAvailable();
       if (!file) {
-        return Promise.reject(
-          new Error('Unable to load font, because no file was specified. ')
-        );
+        throw new Error('Unable to load font, because no file was specified. ');
       }
-      return NativeIconAPI.loadFontWithFileName(...file.split('.'));
+      await NativeIconAPI.loadFontWithFileName(...file.split('.'));
     }
-    return Promise.resolve();
   }
 
   function hasIcon(name) {
@@ -179,6 +201,7 @@ export default function createIconSet(
     getImageSource
   );
   Icon.getImageSource = getImageSource;
+  Icon.getImageSourceSync = getImageSourceSync;
   Icon.loadFont = loadFont;
   Icon.hasIcon = hasIcon;
   Icon.getRawGlyphMap = getRawGlyphMap;

--- a/lib/create-icon-source-cache.js
+++ b/lib/create-icon-source-cache.js
@@ -1,0 +1,27 @@
+const TYPE_VALUE = 'value';
+const TYPE_ERROR = 'error';
+
+export default function createIconSourceCache() {
+  const cache = new Map();
+
+  const setValue = (key, value) =>
+    cache.set(key, { type: TYPE_VALUE, data: value });
+
+  const setError = (key, error) =>
+    cache.set(key, { type: TYPE_ERROR, data: error });
+
+  const has = key => cache.has(key);
+
+  const get = key => {
+    if (!cache.has(key)) {
+      return undefined;
+    }
+    const { type, data } = cache.get(key);
+    if (type === TYPE_ERROR) {
+      throw data;
+    }
+    return data;
+  };
+
+  return { setValue, setError, has, get };
+}

--- a/templates/bundled-icon-set.tpl
+++ b/templates/bundled-icon-set.tpl
@@ -15,4 +15,5 @@ export const {
   TabBarItemIOS,
   ToolbarAndroid,
   getImageSource,
+  getImageSourceSync,
 } = iconSet;

--- a/templates/separated-icon-set.tpl
+++ b/templates/separated-icon-set.tpl
@@ -15,4 +15,5 @@ export const {
   TabBarItemIOS,
   ToolbarAndroid,
   getImageSource,
+  getImageSourceSync,
 } = iconSet;


### PR DESCRIPTION
For things like tab bar items and toolbars that need to be available at boot, it's a bit inconvenient to use async methods as you then need to have some kind of block to the boot of your app. The way this library has handled this in the past is to provide some convenience components that wraps parts of this by first rendering without icons and swap them in once they have been bitmapped on the native side. With "The Slimmening" components like ToolbarAndroid has been extracted making it more problematic providing these convenience components as it would incur redundant dependencies on most consumers. 

As a replacement this PR introduces a new method `getImageSourceSync` to make this all a bit easier to deal with without having to use the components provided by the library. A major downside to this synchronous method however is that it doesn't work with web socket based execution, typically used in debuggers. 

Related: #1124