### PR TITLE
[Mac Catalyst compatibility] Fix temporary directory for icon images

### DIFF
--- a/RNVectorIconsManager/RNVectorIconsManager.m
+++ b/RNVectorIconsManager/RNVectorIconsManager.m
@@ -57,12 +57,13 @@ RCT_EXPORT_MODULE();
 {
   CGFloat screenScale = RCTScreenScale();
   NSString *hexColor = [self hexStringFromColor:color];
-  NSString *fileName = [NSString stringWithFormat:@"tmp/RNVectorIcons_%@_%@_%hu_%.f%@@%.fx.png",
+  NSString *fileName = [NSString stringWithFormat:@"%@RNVectorIcons_%@_%@_%hu_%.f%@@%.fx.png",
+                                                  NSTemporaryDirectory(),
                                                   identifier, fontName,
                                                   [glyph characterAtIndex:0],
                                                   fontSize, hexColor, screenScale];
 
-  return [NSHomeDirectory() stringByAppendingPathComponent:fileName];
+  return fileName;
 }
 
 - (BOOL)createAndSaveGlyphImage:(NSString *)glyph withFont:(UIFont *)font


### PR DESCRIPTION
I tried to use icons for my Mac Catalyst target, but get "Failed to write rendered icon image" error.

This is due to the error from the line 
```objc
return [imageData writeToFile:filePath atomically:YES];
```
in function `createAndSaveGlyphImage` and the filePath is composed with `NSHomeDirectory` and `tmp`.

It turned out `NSHomeDirectory` is
- `/Users/username/Library/Containers/com.example.app/Data/` in macOS
- `/private/var/mobile/Containers/Data/Application/5AAAAAA-AAAA-AAAA-AAAA-AAAAAAA/` in iOS

In iOS, `NSHomeDirectory/tmp` exists naturally and is also known as `NSTemporaryDirectory`, while on mac `NSHomeDirectory/tmp` does not exist and we need to create the `tmp` first in order to write data.

In short, I just change `NSHomeDirectory/tmp` to `NSTemporaryDirectory` to solve the problem for mac target.

Since `NSHomeDirectory/tmp` is equal to `NSTemporaryDirectory` for iOS, there should not be any breaking change.