### PR TITLE
Update package version to patch 6.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-vector-icons",
-  "version": "6.6.0",
+  "version": "6.6.1",
   "description": "Customizable Icons for React Native with support for NavBar/TabBar/ToolbarAndroid, image source and full styling.",
   "main": "dist/index.js",
   "bin": {


### PR DESCRIPTION
Update package version to patch 6.6.1 in order to allow insertion of @react-native-community/toolbar-android take effect