### PR TITLE
Remove relative react-native paths

### DIFF
--- a/Examples/IconExplorer/src/IconList.js
+++ b/Examples/IconExplorer/src/IconList.js
@@ -7,7 +7,7 @@ import {
   Text,
   TextInput,
   View,
-} from './react-native';
+} from 'react-native';
 
 const styles = StyleSheet.create({
   container: {

--- a/Examples/IconExplorer/src/IconSetList.js
+++ b/Examples/IconExplorer/src/IconSetList.js
@@ -8,7 +8,7 @@ import {
   Text,
   TouchableHighlight,
   View,
-} from './react-native';
+} from 'react-native';
 
 import ICON_SETS from './icon-sets';
 

--- a/lib/create-icon-set-from-fontawesome5.js
+++ b/lib/create-icon-set-from-fontawesome5.js
@@ -1,4 +1,4 @@
-import { Platform } from './react-native';
+import { Platform } from 'react-native';
 import createMultiStyleIconSet from './create-multi-style-icon-set';
 
 const FA5Style = {

--- a/lib/create-icon-set.js
+++ b/lib/create-icon-set.js
@@ -6,7 +6,7 @@ import {
   PixelRatio,
   processColor,
   Text,
-} from './react-native';
+} from 'react-native';
 
 import ensureNativeModuleAvailable from './ensure-native-module-available';
 import createIconSourceCache from './create-icon-source-cache';

--- a/lib/ensure-native-module-available.js
+++ b/lib/ensure-native-module-available.js
@@ -1,4 +1,4 @@
-import { Platform, NativeModules } from './react-native';
+import { Platform, NativeModules } from 'react-native';
 
 const NativeIconAPI =
   NativeModules.RNVectorIconsManager || NativeModules.RNVectorIconsModule;

--- a/lib/icon-button.js
+++ b/lib/icon-button.js
@@ -3,7 +3,7 @@ import omit from 'lodash/omit';
 import pick from 'lodash/pick';
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import { StyleSheet, Text, TouchableHighlight, View } from './react-native';
+import { StyleSheet, Text, TouchableHighlight, View } from 'react-native';
 
 const styles = StyleSheet.create({
   container: {

--- a/lib/tab-bar-item-ios.js
+++ b/lib/tab-bar-item-ios.js
@@ -3,7 +3,7 @@ import isEqual from 'lodash/isEqual';
 import pick from 'lodash/pick';
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import { TabBarIOS } from './react-native';
+import { TabBarIOS } from 'react-native';
 
 const ICON_PROP_NAMES = ['iconName', 'iconSize', 'iconColor'];
 const SELECTED_ICON_PROP_NAMES = [


### PR DESCRIPTION
Fixes weird errors when used with jest
```
  ● Test suite failed to run

    TypeError: Cannot read property 'create' of undefined

      at Object.<anonymous> (node_modules/react-native-vector-icons/lib/icon-button.js:8:27)
      at Object.<anonymous> (node_modules/react-native-vector-icons/lib/create-icon-set.js:12:1)
```