### PR TITLE
fix: bug in ToolbarAndroid

### DIFF
--- a/Examples/IconExplorer/src/App.js
+++ b/Examples/IconExplorer/src/App.js
@@ -1,15 +1,21 @@
+/* eslint-disable max-classes-per-file */
 import 'react-native-gesture-handler';
 import React from 'react';
-import { StyleSheet } from 'react-native';
+import { StyleSheet, View } from 'react-native';
 import { createAppContainer } from 'react-navigation';
 import { createStackNavigator } from 'react-navigation-stack';
-
 import IconSetList from './IconSetList';
 import IconList from './IconList';
+import Icon from 'react-native-vector-icons/MaterialIcons';
 
 const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
   header: {
     backgroundColor: 'white',
+    width: '100%',
+    height: 50,
   },
 });
 
@@ -28,20 +34,36 @@ class IconListScreen extends React.Component {
 
 class IconExplorer extends React.Component {
   static navigationOptions = {
-    title: 'Icon Explorer',
-    headerStyle: styles.header,
+    header: null,
   };
 
   render() {
     const { navigate } = this.props.navigation;
     return (
-      <IconSetList
-        navigator={{
-          push({ iconSet, title }) {
-            navigate('IconSet', { title, iconSet });
-          },
-        }}
-      />
+      <View style={styles.container}>
+        <Icon.ToolbarAndroid
+          style={styles.header}
+          logoName="home"
+          iconSize={20}
+          iconColor="black"
+          title="Icon Explorer"
+          actions={[
+            {
+              title: 'Settings',
+              iconName: 'settings',
+              iconSize: 20,
+              show: 'always',
+            },
+          ]}
+        />
+        <IconSetList
+          navigator={{
+            push({ iconSet, title }) {
+              navigate('IconSet', { title, iconSet });
+            },
+          }}
+        />
+      </View>
     );
   }
 }

--- a/lib/toolbar-android.js
+++ b/lib/toolbar-android.js
@@ -3,7 +3,14 @@ import isEqual from 'lodash/isEqual';
 import pick from 'lodash/pick';
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import ToolbarAndroid from '@react-native-community/toolbar-android';
+
+let ToolbarAndroid;
+try {
+  // eslint-disable-next-line global-require
+  ToolbarAndroid = require('@react-native-community/toolbar-android')
+    .defaultProps;
+  // eslint-disable-next-line no-empty
+} catch {}
 
 const ICON_PROP_NAMES = ['iconSize', 'iconColor', 'titleColor'];
 const LOGO_ICON_PROP_NAMES = [...ICON_PROP_NAMES, 'logoName'];
@@ -46,6 +53,15 @@ export default function createToolbarAndroidComponent(
     static defaultProps = {
       iconSize: 24,
     };
+
+    constructor(props) {
+      super(props);
+      if (!ToolbarAndroid) {
+        throw new Error(
+          "ToolbarAndroid is not found, Maybe you don't added @react-native-community/toolbar-android in your dependencies"
+        );
+      }
+    }
 
     state = {
       logo: undefined,

--- a/lib/toolbar-android.js
+++ b/lib/toolbar-android.js
@@ -58,7 +58,7 @@ export default function createToolbarAndroidComponent(
       super(props);
       if (!ToolbarAndroid) {
         throw new Error(
-          "ToolbarAndroid is not found, Maybe you don't added @react-native-community/toolbar-android in your dependencies"
+          'ToolbarAndroid is not found, Maybe you have not added @react-native-community/toolbar-android in your dependencies'
         );
       }
     }

--- a/lib/toolbar-android.js
+++ b/lib/toolbar-android.js
@@ -5,12 +5,11 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 
 let ToolbarAndroid;
-try {
-  // eslint-disable-next-line global-require
-  ToolbarAndroid = require('@react-native-community/toolbar-android')
-    .defaultProps;
-  // eslint-disable-next-line no-empty
-} catch {}
+import('@react-native-community/toolbar-android').then(
+  ({ default: _ToolbarAndroid }) => {
+    ToolbarAndroid = _ToolbarAndroid;
+  }
+);
 
 const ICON_PROP_NAMES = ['iconSize', 'iconColor', 'titleColor'];
 const LOGO_ICON_PROP_NAMES = [...ICON_PROP_NAMES, 'logoName'];


### PR DESCRIPTION
Current behavior:
An error occur when user not installed @react-native-community/toolbar-android
import module throw error

Solution:
require @react-native-community/toolbar-android between try catch 
