### PR TITLE
Require Main Queue for Setup

### DIFF
--- a/RNVectorIconsManager/RNVectorIconsManager.m
+++ b/RNVectorIconsManager/RNVectorIconsManager.m
@@ -33,6 +33,16 @@ NSString *const RNVIErrorDomain = @"org.oblador.react-native-vector-icons";
 
 @implementation RNVectorIconsManager
 
+- (dispatch_queue_t)methodQueue
+{
+    return dispatch_get_main_queue();
+}
+
++ (BOOL)requiresMainQueueSetup
+{
+    return YES;
+}
+
 @synthesize bridge = _bridge;
 RCT_EXPORT_MODULE();
 


### PR DESCRIPTION
Uses `dispatch_get_main_queue` for `methodQueue` and return `YES` for `requiresMainQueueSetup`.

### requiresMainQueueSetup

According to [the documentation in RCTBridgeModule.h](https://github.com/facebook/react-native/blob/a23596f70f9ca8a60382ac065a49cfad39c3f38c/React/Base/RCTBridgeModule.h#L299-L310). Since there is not really much explanation to this, I'm actually not quite sure if this (explicitly marking the module as "main"-thread) makes any difference to now (thread to use is inferred by React). I am creating this PR because as stated in those inline comments I linked, React will stop automatically inferring this in "the future".

### methodQueue

As for the `methodQueue`, I'll need your feedback @oblador. Does any method of yours (e.g. `Icon.getImageSource`) need the main thread? If not, we could also remove the explicit `dispatch_get_main_queue` call here to make calls such as getImageSources run on a background thread. The docs for this function are also found in [RCTBridgeModule.h](https://github.com/facebook/react-native/blob/a23596f70f9ca8a60382ac065a49cfad39c3f38c/React/Base/RCTBridgeModule.h#L125-L146)