### PR TITLE
Fix iOS Asset Linking

### DIFF
--- a/RNVectorIcons.podspec
+++ b/RNVectorIcons.podspec
@@ -12,7 +12,6 @@ Pod::Spec.new do |s|
   s.platforms      = { :ios => "9.0", :tvos => "9.0" }
   s.source         = { :git => "https://github.com/oblador/react-native-vector-icons.git", :tag => "v#{s.version}" }
   s.source_files   = 'RNVectorIconsManager/**/*.{h,m}'
-  s.resources      = "Fonts/*.ttf"
   s.preserve_paths = "**/*.js"
   s.dependency 'React'
 


### PR DESCRIPTION
Because `RNVectorIcons.podspec` includes a `resources` line AND `react-native-config.js` includes an `assets` line, each font file is being copied into the iOS project twice when using react native >= 0.60 (which supports autolinking) and running `react-native link`. This commit removes the `resources` line from the podspec, making it so that just a single copy of the assets are added to the project. I chose to remove it from the podspec rather than the react-native config because the react-native config also copies assets for Android and I didn't want to break that functionality.

Closes #1173