### PR TITLE
Use full glyph as filename for getImageSource

### DIFF
--- a/RNVectorIconsManager/RNVectorIconsManager.m
+++ b/RNVectorIconsManager/RNVectorIconsManager.m
@@ -57,10 +57,9 @@ RCT_EXPORT_MODULE();
 {
   CGFloat screenScale = RCTScreenScale();
   NSString *hexColor = [self hexStringFromColor:color];
-  NSString *fileName = [NSString stringWithFormat:@"%@RNVectorIcons_%@_%@_%hu_%.f%@@%.fx.png",
+  NSString *fileName = [NSString stringWithFormat:@"%@RNVectorIcons_%@_%@_%@_%.f%@@%.fx.png",
                                                   NSTemporaryDirectory(),
-                                                  identifier, fontName,
-                                                  [glyph characterAtIndex:0],
+                                                  identifier, fontName, glyph,
                                                   fontSize, hexColor, screenScale];
 
   return fileName;


### PR DESCRIPTION
fixes #1205 , fixes #1024