### PR TITLE
Accept any type for color prop

### DIFF
--- a/lib/create-icon-set.js
+++ b/lib/create-icon-set.js
@@ -46,7 +46,7 @@ export default function createIconSet(
       allowFontScaling: PropTypes.bool,
       name: IconNamePropType,
       size: PropTypes.number,
-      color: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+      color: PropTypes.any, // eslint-disable-line react/forbid-prop-types
       children: PropTypes.node,
       style: PropTypes.any, // eslint-disable-line react/forbid-prop-types
     };

--- a/lib/icon-button.js
+++ b/lib/icon-button.js
@@ -75,7 +75,7 @@ export default function createIconButtonComponent(Icon) {
         PropTypes.number,
       ]),
       borderRadius: PropTypes.number,
-      color: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+      color: PropTypes.any, // eslint-disable-line react/forbid-prop-types
       size: PropTypes.number,
       iconStyle: PropTypes.any, // eslint-disable-line react/forbid-prop-types
       style: PropTypes.any, // eslint-disable-line react/forbid-prop-types

--- a/lib/tab-bar-item-ios.js
+++ b/lib/tab-bar-item-ios.js
@@ -27,11 +27,8 @@ export default function createTabBarItemIOSComponent(
       iconName: IconNamePropType.isRequired,
       selectedIconName: IconNamePropType,
       iconSize: PropTypes.number,
-      iconColor: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-      selectedIconColor: PropTypes.oneOfType([
-        PropTypes.string,
-        PropTypes.number,
-      ]),
+      iconColor: PropTypes.any, // eslint-disable-line react/forbid-prop-types
+      selectedIconColor: PropTypes.any, // eslint-disable-line react/forbid-prop-types
     };
 
     static defaultProps = {


### PR DESCRIPTION
As outlined in #1240, passing platform specific color types causes useless warnings, and using the proper type would break backwards compatibility with older versions of react-native. So instead this PR changes the color prop types to just accept any value, and rely on the style validation instead. 