### PR TITLE
https://github.com/oblador/react-native-vector-icons/issues/1265

### DIFF
--- a/fonts.gradle
+++ b/fonts.gradle
@@ -5,54 +5,54 @@
 def config = project.hasProperty("vectoricons") ? project.vectoricons : [];
 
 def iconFontsDir = config.iconFontsDir ?: "../../node_modules/react-native-vector-icons/Fonts";
-def iconFontNames = config.iconFontNames ?: [ "*.ttf" ];
+def iconFontNames = config.iconFontNames ?: ["*.ttf"];
 
-gradle.projectsEvaluated {
-    android.applicationVariants.all { def variant ->
-        def targetName = variant.name.capitalize()
-        def targetPath = variant.dirName
 
-        // Create task for copying fonts
-        def currentFontTask = tasks.create(
-                name: "copy${targetName}IconFonts",
-                type: Copy) {
-            into("${buildDir}/intermediates")
+android.applicationVariants.all { def variant ->
+  def targetName = variant.name.capitalize()
+  def targetPath = variant.dirName
 
-            iconFontNames.each { fontName ->
+  // Create task for copying fonts
+  def currentFontTask = tasks.create(
+    name: "copy${targetName}IconFonts",
+    type: Copy) {
+    into("${buildDir}/intermediates")
 
-              from(iconFontsDir) {
-                include(fontName)
-                into("assets/${targetPath}/fonts/")
-              }
+    iconFontNames.each { fontName ->
 
-              // Workaround for Android Gradle Plugin 3.2+ new asset directory
-              from(iconFontsDir) {
-                include(fontName)
-                into("merged_assets/${variant.name}/merge${targetName}Assets/out/fonts/")
-              }
+      from(iconFontsDir) {
+        include(fontName)
+        into("assets/${targetPath}/fonts/")
+      }
 
-              // Workaround for Android Gradle Plugin 3.4+ new asset directory
-              from(iconFontsDir) {
-                include(fontName)
-                into("merged_assets/${variant.name}/out/fonts/")
-              }
-            }
-        }
+      // Workaround for Android Gradle Plugin 3.2+ new asset directory
+      from(iconFontsDir) {
+        include(fontName)
+        into("merged_assets/${variant.name}/merge${targetName}Assets/out/fonts/")
+      }
 
-        currentFontTask.dependsOn("merge${targetName}Resources")
-        currentFontTask.dependsOn("merge${targetName}Assets")
-
-        [
-            "processArmeabi-v7a${targetName}Resources",
-            "processX86${targetName}Resources",
-            "processUniversal${targetName}Resources",
-            "process${targetName}Resources"
-        ].each { name ->
-            Task dependentTask = tasks.findByPath(name);
-
-            if (dependentTask != null) {
-                dependentTask.dependsOn(currentFontTask)
-            }
-        }
+      // Workaround for Android Gradle Plugin 3.4+ new asset directory
+      from(iconFontsDir) {
+        include(fontName)
+        into("merged_assets/${variant.name}/out/fonts/")
+      }
     }
+  }
+
+  currentFontTask.dependsOn("merge${targetName}Resources")
+  currentFontTask.dependsOn("merge${targetName}Assets")
+
+  [
+    "processArmeabi-v7a${targetName}Resources",
+    "processX86${targetName}Resources",
+    "processUniversal${targetName}Resources",
+    "process${targetName}Resources"
+  ].each { name ->
+    Task dependentTask = tasks.findByPath(name);
+
+    if (dependentTask != null) {
+      dependentTask.dependsOn(currentFontTask)
+    }
+  }
 }
+

--- a/fonts.gradle
+++ b/fonts.gradle
@@ -5,54 +5,54 @@
 def config = project.hasProperty("vectoricons") ? project.vectoricons : [];
 
 def iconFontsDir = config.iconFontsDir ?: "../../node_modules/react-native-vector-icons/Fonts";
-def iconFontNames = config.iconFontNames ?: ["*.ttf"];
+def iconFontNames = config.iconFontNames ?: [ "*.ttf" ];
 
 
-android.applicationVariants.all { def variant ->
-  def targetName = variant.name.capitalize()
-  def targetPath = variant.dirName
+    android.applicationVariants.all { def variant ->
+        def targetName = variant.name.capitalize()
+        def targetPath = variant.dirName
 
-  // Create task for copying fonts
-  def currentFontTask = tasks.create(
-    name: "copy${targetName}IconFonts",
-    type: Copy) {
-    into("${buildDir}/intermediates")
+        // Create task for copying fonts
+        def currentFontTask = tasks.create(
+                name: "copy${targetName}IconFonts",
+                type: Copy) {
+            into("${buildDir}/intermediates")
 
-    iconFontNames.each { fontName ->
+            iconFontNames.each { fontName ->
 
-      from(iconFontsDir) {
-        include(fontName)
-        into("assets/${targetPath}/fonts/")
-      }
+              from(iconFontsDir) {
+                include(fontName)
+                into("assets/${targetPath}/fonts/")
+              }
 
-      // Workaround for Android Gradle Plugin 3.2+ new asset directory
-      from(iconFontsDir) {
-        include(fontName)
-        into("merged_assets/${variant.name}/merge${targetName}Assets/out/fonts/")
-      }
+              // Workaround for Android Gradle Plugin 3.2+ new asset directory
+              from(iconFontsDir) {
+                include(fontName)
+                into("merged_assets/${variant.name}/merge${targetName}Assets/out/fonts/")
+              }
 
-      // Workaround for Android Gradle Plugin 3.4+ new asset directory
-      from(iconFontsDir) {
-        include(fontName)
-        into("merged_assets/${variant.name}/out/fonts/")
-      }
+              // Workaround for Android Gradle Plugin 3.4+ new asset directory
+              from(iconFontsDir) {
+                include(fontName)
+                into("merged_assets/${variant.name}/out/fonts/")
+              }
+            }
+        }
+
+        currentFontTask.dependsOn("merge${targetName}Resources")
+        currentFontTask.dependsOn("merge${targetName}Assets")
+
+        [
+            "processArmeabi-v7a${targetName}Resources",
+            "processX86${targetName}Resources",
+            "processUniversal${targetName}Resources",
+            "process${targetName}Resources"
+        ].each { name ->
+            Task dependentTask = tasks.findByPath(name);
+
+            if (dependentTask != null) {
+                dependentTask.dependsOn(currentFontTask)
+            }
+        }
     }
-  }
-
-  currentFontTask.dependsOn("merge${targetName}Resources")
-  currentFontTask.dependsOn("merge${targetName}Assets")
-
-  [
-    "processArmeabi-v7a${targetName}Resources",
-    "processX86${targetName}Resources",
-    "processUniversal${targetName}Resources",
-    "process${targetName}Resources"
-  ].each { name ->
-    Task dependentTask = tasks.findByPath(name);
-
-    if (dependentTask != null) {
-      dependentTask.dependsOn(currentFontTask)
-    }
-  }
-}
 


### PR DESCRIPTION
#1265,Android Platform, Fonts not being copied if using Android gradle plugin 4.1.0 => **FIXED**

Tested on following versions of Android Gradle Plugin:

- 4.1.0
- 4.0.1
- 3.5.3

As of now, the creation and addition of tasks to the Task Graph were depended upon to project being evaluated while Gradle build lifecycle i.e `gradle.projectsEvaluated`. That is while the Gradle build is in the execution phase due to which the task to copy fonts was not being added to the TaskGraph(of tasks to be executed). 

Therefore, the listener to the project being evaluated is now removed. Now, the tasks are added to the TaskGraph while in the **configuration phase**, thus our `copy{}IconFonts` task can be run in the **execution phase** of Gradle Build.