### PR TITLE
fix(android): refactor font copy / support android gradle plugin 4.1+

### DIFF
--- a/fonts.gradle
+++ b/fonts.gradle
@@ -1,58 +1,51 @@
 /**
  * Task to copy icon font files
  */
+afterEvaluate {
+    def config = project.hasProperty("vectoricons") ? project.vectoricons : [];
+    def iconFontsDir = config.iconFontsDir ?: "../../node_modules/react-native-vector-icons/Fonts";
+    def iconFontNames = config.iconFontNames ?: [ "*.ttf" ];
 
-def config = project.hasProperty("vectoricons") ? project.vectoricons : [];
-
-def iconFontsDir = config.iconFontsDir ?: "../../node_modules/react-native-vector-icons/Fonts";
-def iconFontNames = config.iconFontNames ?: [ "*.ttf" ];
-
-gradle.projectsEvaluated {
     android.applicationVariants.all { def variant ->
         def targetName = variant.name.capitalize()
         def targetPath = variant.dirName
 
         // Create task for copying fonts
-        def currentFontTask = tasks.create(
-                name: "copy${targetName}IconFonts",
-                type: Copy) {
-            into("${buildDir}/intermediates")
+        def currentFontCopyTask = tasks.create(
+            name: "copy${targetName}ReactNativeVectorIconFonts",
+            type: Copy) {
+            group = "react"
+            description = "copy fonts into ${targetName}."
+
+            into("$buildDir/intermediates")
 
             iconFontNames.each { fontName ->
 
-              from(iconFontsDir) {
-                include(fontName)
-                into("assets/${targetPath}/fonts/")
-              }
+                from(iconFontsDir) {
+                    include(fontName)
+                    into("assets/${targetPath}/fonts/")
+                }
 
-              // Workaround for Android Gradle Plugin 3.2+ new asset directory
-              from(iconFontsDir) {
-                include(fontName)
-                into("merged_assets/${variant.name}/merge${targetName}Assets/out/fonts/")
-              }
+                // Workaround for Android Gradle Plugin 3.2+ new asset directory
+                from(iconFontsDir) {
+                    include(fontName)
+                    into("merged_assets/${variant.name}/merge${targetName}Assets/out/fonts/")
+                }
 
-              // Workaround for Android Gradle Plugin 3.4+ new asset directory
-              from(iconFontsDir) {
-                include(fontName)
-                into("merged_assets/${variant.name}/out/fonts/")
-              }
+                // Workaround for Android Gradle Plugin 3.4+ new asset directory
+                from(iconFontsDir) {
+                    include(fontName)
+                    into("merged_assets/${variant.name}/out/fonts/")
+                }
             }
+
+            // mergeAssets must run first, as it clears the intermediates directory
+            dependsOn(variant.mergeAssetsProvider.get())
         }
 
-        currentFontTask.dependsOn("merge${targetName}Resources")
-        currentFontTask.dependsOn("merge${targetName}Assets")
-
-        [
-            "processArmeabi-v7a${targetName}Resources",
-            "processX86${targetName}Resources",
-            "processUniversal${targetName}Resources",
-            "process${targetName}Resources"
-        ].each { name ->
-            Task dependentTask = tasks.findByPath(name);
-
-            if (dependentTask != null) {
-                dependentTask.dependsOn(currentFontTask)
-            }
-        }
+        // mergeResources task runs before the bundle file is copied to the intermediate asset directory from Android plugin 4.1+.
+        // This ensures to copy the bundle file before mergeResources task starts
+        def mergeResourcesTask = tasks.findByName("merge${targetName}Resources")
+        mergeResourcesTask.dependsOn(currentFontCopyTask)
     }
 }


### PR DESCRIPTION
Hi there! Thanks so much for this module, @oblador, I've been using it quite a while.

I noticed in #1265 that Android Gradle Plugin 4.1 broke the font copy gradle task, similar to the way [react-native bundle copy had to be altered ](https://github.com/facebook/react-native/pull/30177) to support that version 

I had time to look at their bundle copy and updated the font copy here to more closely match their script's copy task: https://github.com/facebook/react-native/blob/c76070412fccdaa82bf4af3c94809d04ae71777e/react.gradle#L282-L317

Previously I was not able to see my react-native-vector-icons in the APK in release mode with android gradle plugin 4.1 but with these changes I can now see them. It should be backwards compatible as well and my build uses flavors and ABI splits so those appear fine to me in testing as well.

Changes:

- react-native JS bundle doesn't copy per-release target
- react-native JS bundle adds the copy task as dependent very carefully now!
- I added some metadata for the task, a "group" and "description"
- Fixed formatting, 4-space indents was predominant, I went with that everywhere

this is based heavily off the react-native JS bundle copy task
this was developed in collaboration with @gulshan183

Fixes #1265
Obsoletes #1271

I am currently using this as a patch 
[react-native-vector-icons+8.0.0.patch.txt](https://github.com/oblador/react-native-vector-icons/files/5969273/react-native-vector-icons%2B8.0.0.patch.txt) (remove the .txt extension and drop it in patches directory) with [patch-package](https://github.com/ds300/patch-package) in case anyone else wants to try it out or needs it now

