### PR TITLE
Import from react-native directly

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -9,11 +9,6 @@
     "prettier"
   ],
   "parser": "babel-eslint",
-  "settings": {
-    "import/ignore": [
-      "lib/react-native.js"
-    ]
-  },
   "rules": {
     "react/jsx-filename-extension": [1, { "extensions": [".js", ".jsx"] }],
     "react/require-default-props": [0],

--- a/Examples/IconExplorer/src/IconList.js
+++ b/Examples/IconExplorer/src/IconList.js
@@ -7,7 +7,7 @@ import {
   Text,
   TextInput,
   View,
-} from './react-native';
+} from 'react-native';
 
 const styles = StyleSheet.create({
   container: {

--- a/Examples/IconExplorer/src/IconSetList.js
+++ b/Examples/IconExplorer/src/IconSetList.js
@@ -8,7 +8,7 @@ import {
   Text,
   TouchableHighlight,
   View,
-} from './react-native';
+} from 'react-native';
 
 import ICON_SETS from './icon-sets';
 

--- a/Examples/IconExplorer/src/react-native.android.js
+++ b/Examples/IconExplorer/src/react-native.android.js
@@ -1,1 +1,0 @@
-export * from 'react-native';

--- a/Examples/IconExplorer/src/react-native.ios.js
+++ b/Examples/IconExplorer/src/react-native.ios.js
@@ -1,1 +1,0 @@
-export * from 'react-native';

--- a/Examples/IconExplorer/src/react-native.osx.js
+++ b/Examples/IconExplorer/src/react-native.osx.js
@@ -1,1 +1,0 @@
-export * from 'react-native-desktop';

--- a/Examples/IconExplorer/src/react-native.windows.js
+++ b/Examples/IconExplorer/src/react-native.windows.js
@@ -1,1 +1,0 @@
-export * from 'react-native';

--- a/README.md
+++ b/README.md
@@ -199,14 +199,14 @@ These steps are optional and only needed if you want to use the `Icon.getImageSo
   }
   ```
 
-### OSX via [`react-native-desktop`](https://github.com/ptmt/react-native-desktop)
+### macOS via [`react-native-macos`](https://github.com/microsoft/react-native-macos)
 
 - Browse to `node_modules/react-native-vector-icons` and drag the folder `Fonts` to your project in Xcode. **Make sure your app is checked under "Add to targets" and that "Create folder references" is checked**.
 - Edit `Info.plist` and add a property called **Application fonts resource path** (or `ATSApplicationFontsPath` if Xcode won't autocomplete/not using Xcode) and type `Fonts` as the value.
 
 _Note: you need to recompile your project after adding new fonts, also ensure that the `Fonts` folder also appear under **Copy Bundle Resources** in **Build Phases**._
 
-### Windows via [`react-native-windows`](https://github.com/ReactWindows/react-native-windows)
+### Windows via [`react-native-windows`](https://github.com/microsoft/react-native-windows)
 
 - In the top level projects (/windows/project-name/Assets), copy and paste the font files.
 - Open your solution in Visual Studio, right click the Assets folder in your solution, click **Add > Existing Item**.

--- a/lib/create-icon-set-from-fontawesome5.js
+++ b/lib/create-icon-set-from-fontawesome5.js
@@ -1,4 +1,4 @@
-import { Platform } from './react-native';
+import { Platform } from 'react-native';
 import createMultiStyleIconSet from './create-multi-style-icon-set';
 
 const FA5Style = {

--- a/lib/create-icon-set.js
+++ b/lib/create-icon-set.js
@@ -6,7 +6,7 @@ import {
   PixelRatio,
   processColor,
   Text,
-} from './react-native';
+} from 'react-native';
 
 import ensureNativeModuleAvailable from './ensure-native-module-available';
 import createIconSourceCache from './create-icon-source-cache';

--- a/lib/ensure-native-module-available.js
+++ b/lib/ensure-native-module-available.js
@@ -1,4 +1,4 @@
-import { Platform, NativeModules } from './react-native';
+import { Platform, NativeModules } from 'react-native';
 
 const NativeIconAPI =
   NativeModules.RNVectorIconsManager || NativeModules.RNVectorIconsModule;

--- a/lib/icon-button.js
+++ b/lib/icon-button.js
@@ -3,7 +3,7 @@ import omit from 'lodash.omit';
 import pick from 'lodash.pick';
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import { StyleSheet, Text, TouchableHighlight, View } from './react-native';
+import { StyleSheet, Text, TouchableHighlight, View } from 'react-native';
 
 const styles = StyleSheet.create({
   container: {

--- a/lib/react-native.js
+++ b/lib/react-native.js
@@ -1,1 +1,0 @@
-export * from 'react-native';

--- a/lib/react-native.osx.js
+++ b/lib/react-native.osx.js
@@ -1,3 +1,0 @@
-/* eslint-disable import/no-unresolved */
-
-export * from 'react-native-desktop';

--- a/lib/react-native.web.js
+++ b/lib/react-native.web.js
@@ -1,3 +1,0 @@
-/* eslint-disable import/no-unresolved */
-
-export * from 'react-native-web';


### PR DESCRIPTION
Due to how `react-native-web` and `react-native-desktop` (old project for macos) was set up in the beginning it required this library to have a unified import of `react-native` like libraries. This should no longer be needed, and the practice triggers deprecation warnings as reported in #1381.