### PR TITLE
Replace the unsupported/insecure lodash.template package with lodash

### DIFF
--- a/bin/generate-material-icons.js
+++ b/bin/generate-material-icons.js
@@ -2,7 +2,7 @@
 /* eslint-disable no-console */
 
 const omit = require('lodash.omit');
-const lodashTemplate = require('lodash.template');
+const lodashTemplate = require('lodash/template');
 const fs = require('fs');
 const path = require('path');
 const yargs = require('yargs');

--- a/lib/generate-icon-set-from-css.js
+++ b/lib/generate-icon-set-from-css.js
@@ -1,4 +1,4 @@
-const lodashTemplate = require('lodash.template');
+const lodashTemplate = require('lodash/template');
 const fromPairs = require('lodash.frompairs');
 const fs = require('fs');
 

--- a/package.json
+++ b/package.json
@@ -61,12 +61,12 @@
   },
   "license": "MIT",
   "dependencies": {
+    "lodash": "^4.17.21",
     "lodash.frompairs": "^4.0.1",
     "lodash.isequal": "^4.5.0",
     "lodash.isstring": "^4.0.1",
     "lodash.omit": "^4.5.0",
     "lodash.pick": "^4.4.0",
-    "lodash.template": "^4.5.0",
     "prop-types": "^15.7.2",
     "yargs": "^16.1.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1705,11 +1705,6 @@ locate-path@^2.0.0:
     p-locate "^2.0.0"
     path-exists "^3.0.0"
 
-lodash._reinterpolate@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
-  integrity sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=
-
 lodash.frompairs@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/lodash.frompairs/-/lodash.frompairs-4.0.1.tgz#bc4e5207fa2757c136e573614e9664506b2b1bd2"
@@ -1735,25 +1730,15 @@ lodash.pick@^4.4.0:
   resolved "https://registry.yarnpkg.com/lodash.pick/-/lodash.pick-4.4.0.tgz#52f05610fff9ded422611441ed1fc123a03001b3"
   integrity sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM=
 
-lodash.template@^4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/lodash.template/-/lodash.template-4.5.0.tgz#f976195cf3f347d0d5f52483569fe8031ccce8ab"
-  integrity sha512-84vYFxIkmidUiFxidA/KjjH9pAycqW+h980j7Fuz5qxRtO9pgB7MDFTdys1N7A5mcucRiDyEq4fusljItR1T/A==
-  dependencies:
-    lodash._reinterpolate "^3.0.0"
-    lodash.templatesettings "^4.0.0"
-
-lodash.templatesettings@^4.0.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/lodash.templatesettings/-/lodash.templatesettings-4.2.0.tgz#e481310f049d3cf6d47e912ad09313b154f0fb33"
-  integrity sha512-stgLz+i3Aa9mZgnjr/O+v9ruKZsPsndy7qPZOchbqk2cnTU1ZaldKK+v7m54WoKIyxiuMZTKT2H81F8BeAc3ZQ==
-  dependencies:
-    lodash._reinterpolate "^3.0.0"
-
 lodash@^4.17.13, lodash@^4.17.14:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
+
+lodash@^4.17.21:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
 loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"


### PR DESCRIPTION
Resolves #1353

`lodash.template` is reported as having a "high severity" security vulnerability: https://app.snyk.io/vuln/SNYK-JS-LODASHTEMPLATE-1088054

Thus, `react-native-vector-icons` currently passes this concern along to consuming applications.

`lodash.template` is also unsupported (along with all of the separate `lodash` module packages, I believe), so there is unlikely to ever be a fix. Instead, regular `lodash` should be used, which has been updated to address this vulnerability. This PR simply makes that change.

### Testing

Ran `yarn`, `npm test`, and `yarn build` for a few of the icon libraries (the general `yarn build` fails for me though, even before this change, I _think_ due to lack of `fontCustom`? The Contributing guide seems to be out-of-date here, `brew` isn't aware of anything by that name). Also tested in a React Native app (although I don't think the code in question actually runs in React Native so wasn't expecting any change there, but just to be sure).