### PR TITLE
Simplify Android font bundling

### DIFF
--- a/fonts.gradle
+++ b/fonts.gradle
@@ -1,4 +1,9 @@
 /**
+ * Register font asset source folder
+ */
+android.sourceSets.main.assets.srcDirs += file("$buildDir/intermediates/ReactNativeVectorIcons")
+
+/**
  * Task to copy icon font files
  */
 afterEvaluate {
@@ -6,46 +11,22 @@ afterEvaluate {
     def iconFontsDir = config.iconFontsDir ?: "../../node_modules/react-native-vector-icons/Fonts";
     def iconFontNames = config.iconFontNames ?: [ "*.ttf" ];
 
+    def fontCopyTask = tasks.create(
+        name: "copyReactNativeVectorIconFonts",
+        type: Copy) {
+        description = "copy vector icon fonts."
+        into "$buildDir/intermediates/ReactNativeVectorIcons/fonts"
+
+        iconFontNames.each { fontName ->
+            from(iconFontsDir) {
+                include(fontName)
+            }
+        }
+    }
+
     android.applicationVariants.all { def variant ->
         def targetName = variant.name.capitalize()
-        def targetPath = variant.dirName
-
-        // Create task for copying fonts
-        def currentFontCopyTask = tasks.create(
-            name: "copy${targetName}ReactNativeVectorIconFonts",
-            type: Copy) {
-            group = "react"
-            description = "copy fonts into ${targetName}."
-
-            into("$buildDir/intermediates")
-
-            iconFontNames.each { fontName ->
-
-                from(iconFontsDir) {
-                    include(fontName)
-                    into("assets/${targetPath}/fonts/")
-                }
-
-                // Workaround for Android Gradle Plugin 3.2+ new asset directory
-                from(iconFontsDir) {
-                    include(fontName)
-                    into("merged_assets/${variant.name}/merge${targetName}Assets/out/fonts/")
-                }
-
-                // Workaround for Android Gradle Plugin 3.4+ new asset directory
-                from(iconFontsDir) {
-                    include(fontName)
-                    into("merged_assets/${variant.name}/out/fonts/")
-                }
-            }
-
-            // mergeAssets must run first, as it clears the intermediates directory
-            dependsOn(variant.mergeAssetsProvider.get())
-        }
-
-        // mergeResources task runs before the bundle file is copied to the intermediate asset directory from Android plugin 4.1+.
-        // This ensures to copy the bundle file before mergeResources task starts
-        def mergeResourcesTask = tasks.findByName("merge${targetName}Resources")
-        mergeResourcesTask.dependsOn(currentFontCopyTask)
+        def generateAssetsTask = tasks.findByName("generate${targetName}Assets")
+        generateAssetsTask.dependsOn(fontCopyTask)
     }
 }


### PR DESCRIPTION
Registers font files as assets instead of manually merging.  This avoids needing to guess at android gradle's internal structure, which may change between versions.

Also fixes dependency warnings in newer build chains:
```
> Task :app:compressDebugAssets
Execution optimizations have been disabled for task ':app:compressDebugAssets' to ensure correctness due to
the following reasons:
  - Gradle detected a problem with the following location: '[...]'. Reason: Task ':app:compressDebugAssets'
    uses this output of task ':app:copyDebugReactNativeVectorIconFonts' without declaring an explicit or
    implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks
    are executed. Please refer to https://docs.gradle.org/7.0.2/userguide/validation_problems.html#implicit_dependency
    for more details about this problem.
```