### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,10 +189,11 @@ These steps are optional and only needed if you want to use the `Icon.getImageSo
   }
 
   dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile "com.android.support:appcompat-v7:23.0.1"
-    compile "com.facebook.react:react-native:+"  // From node_modules
-  + compile project(':react-native-vector-icons')
+    implementation fileTree(dir: "libs", include: ["*.jar"])
+    //noinspection GradleDynamicVersion
+    implementation "com.facebook.react:react-native:+"  // From node_modules
+
+  + implementation project(':react-native-vector-icons')
   }
   ```
 


### PR DESCRIPTION
Update some diffs in README.md to match the current `npx react-native init` boilerplate.

Right now it can be quite confusing to set up this package for beginners because the `compile` statements are no more present in `android/app/build.gradle`. See https://github.com/facebook/react-native/blob/v0.67.4/template/android/app/build.gradle#L192 for reference.