### PR TITLE
fix (ios): support kCTFontManagerErrorDuplicatedName as allowable error

### DIFF
--- a/RNVectorIconsManager/RNVectorIconsManager.m
+++ b/RNVectorIconsManager/RNVectorIconsManager.m
@@ -151,7 +151,7 @@ RCT_EXPORT_METHOD(
     CFErrorRef errorRef = NULL;
     if (CTFontManagerRegisterGraphicsFont(font, &errorRef) == NO) {
       NSError *error = (__bridge NSError *)errorRef;
-      if (error.code == kCTFontManagerErrorAlreadyRegistered) {
+      if (error.code == kCTFontManagerErrorAlreadyRegistered || error.code == kCTFontManagerErrorDuplicatedName) {
         resolve(nil);
       } else {
         reject(@"font_load_failed", @"Font failed to load", error);


### PR DESCRIPTION
fixes: #1465 

---

There might be a root cause here somewhere, but it looks like the error I'm seeing is the duplicate name. Which I assume is an iteration of already registered.