### PR TITLE
Improve Error Logging for Font Imports

### DIFF
--- a/RNVectorIconsManager/RNVectorIconsManager.m
+++ b/RNVectorIconsManager/RNVectorIconsManager.m
@@ -154,7 +154,8 @@ RCT_EXPORT_METHOD(
       if (error.code == kCTFontManagerErrorAlreadyRegistered) {
         resolve(nil);
       } else {
-        reject(@"font_load_failed", @"Font failed to load", error);
+        NSString *errorMessage = [NSString stringWithFormat:@"Font '%@' failed to load", fontFileName];
+        reject(@"font_load_failed", errorMessage, error);
       }
     } else {
       resolve(nil);


### PR DESCRIPTION
Hello, I was troubleshooting some console errors which were showing up while upgrading my react-native version at work and felt like this would be a useful addition to the library. Please take a look.

Thank you!
--

Improve error logging for failed font imports by including the missing fonts name in the error message. Current exception message is not detailed enough to help developers troubleshoot which exact font is failing without jumping from debugging JS --> Objective C code.