### PR TITLE
Update README with monorepo info for Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,35 @@ project.ext.vectoricons = [
 apply from: "../../node_modules/react-native-vector-icons/fonts.gradle"
 ```
 
+<details>
+<summary>⚠️ Monorepo configuration</summary>
+<br>
+If you are working in a monorepo, you'll need to point to the correct location of the `fonts.gradle` script and of the Font files, **relative to the android/app/build.gradle file**. For example if your repo uses this common structure:
+  
+  
+```text
+your-monorepo/
+├─ node_modules/
+│  ├─ react-native-vector-icons
+├─ apps/
+│  ├─ YourApp/
+│  │  ├─ android/
+│  │  │  ├─ app/
+│  │  │  │  ├─ build.gradle
+```
+
+you will need to update the paths to:
+```diff
+project.ext.vectoricons = [
++ iconFontsDir: "../../../../node_modules/react-native-vector-icons/Fonts",
+  iconFontNames: ["WhateverFonts", "..."]
+]
+
+- apply from: "../../node_modules/react-native-vector-icons/fonts.gradle"
++ apply from: "../../../../node_modules/react-native-vector-icons/fonts.gradle
+```
+</details>
+
 #### Option: Manually
 
 - Copy the contents in the `Fonts` folder to `android/app/src/main/assets/fonts` (_note lowercase fonts folder_).

--- a/README.md
+++ b/README.md
@@ -142,7 +142,9 @@ apply from: "../../node_modules/react-native-vector-icons/fonts.gradle"
 ```
 
 <details>
-<summary>⚠️ Monorepo configuration</summary>
+<summary>Monorepo configuration</summary>
+
+<!-- ##### Monorepo configuration -->
 <br>
 If you are working in a monorepo, you'll need to point to the correct location of the `fonts.gradle` script and of the Font files, **relative to the android/app/build.gradle file**. For example if your repo uses this common structure:
   
@@ -168,6 +170,8 @@ project.ext.vectoricons = [
 - apply from: "../../node_modules/react-native-vector-icons/fonts.gradle"
 + apply from: "../../../../node_modules/react-native-vector-icons/fonts.gradle
 ```
+  
+  ⚠️ There have been [reported issues](https://github.com/oblador/react-native-vector-icons/issues/1281#issuecomment-1363201537) when using RNVI < 9.0.0 in a monorepo, so make sure you are on 9+.
 </details>
 
 #### Option: Manually


### PR DESCRIPTION
Just spent a few hours trying to understand why my icons where not showing on Android after changing to a monorepo.

This issue https://github.com/oblador/react-native-vector-icons/issues/1183 requests that the docs be updated to mention the extra config necessary for RNVI to work well in a monorepo.

This PR addresses exactly this.

fixes: https://github.com/oblador/react-native-vector-icons/issues/1183
fixes: https://github.com/oblador/react-native-vector-icons/issues/1117

Please let me know if anything is unclear or inaccurate.

✌️