### PR TITLE
Replace tabBarOptions with screenOptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -555,7 +555,7 @@ function MyTabs() {
   return (
     <Tab.Navigator
       initialRouteName="Feed"
-      tabBarOptions={{
+      screenOptions={{
         activeTintColor: '#e91e63',
       }}
     >


### PR DESCRIPTION
`tabBarOptions` is deprecated in [react navigation](https://reactnavigation.org/docs/tab-based-navigation).