### PR TITLE
Attempted import error: 'pick' is not exported from './object-utils' (imported as 'pick').

### DIFF
--- a/lib/object-utils.js
+++ b/lib/object-utils.js
@@ -1,4 +1,4 @@
-const pick = (obj, ...keys) =>
+export const pick = (obj, ...keys) =>
   keys
     .flat()
     .filter(key => Object.prototype.hasOwnProperty.call(obj, key))
@@ -7,7 +7,7 @@ const pick = (obj, ...keys) =>
       return acc;
     }, {});
 
-const omit = (obj, ...keysToOmit) => {
+export const omit = (obj, ...keysToOmit) => {
   const keysToOmitSet = new Set(keysToOmit.flat());
   return Object.getOwnPropertyNames(obj)
     .filter(key => !keysToOmitSet.has(key))
@@ -17,4 +17,4 @@ const omit = (obj, ...keysToOmit) => {
     }, {});
 };
 
-module.exports = { pick, omit };
+module.export = { pick, omit };


### PR DESCRIPTION
During build the following error would occur:
`Attempted import error: 'pick' is not exported from './object-utils' (imported as 'pick').`
These chances solve this issue by changing "exports" to "export" and making it compatible with the rest of the code.
