### PR TITLE
fix: font weight being overriden for variable fonts

### DIFF
--- a/lib/create-icon-set.js
+++ b/lib/create-icon-set.js
@@ -60,7 +60,6 @@ export default function createIconSet(
 
       const styleOverrides = {
         fontFamily: fontReference,
-        fontWeight: 'normal',
         fontStyle: 'normal',
       };
 


### PR DESCRIPTION
Font weights are being overridden when it's being passed from the component style properties.
I don't know if that's gonna break the current implementation of other font icons, but as far as I tested react native automatically applies `normal` fontWeight to the text if you don't pass it.

You can check font weights here with material symbols:
https://fonts.google.com/icons

Android: WIP