### PR TITLE
Fix to get working with react-native-web

### DIFF
--- a/lib/NativeRNVectorIcons.web.js
+++ b/lib/NativeRNVectorIcons.web.js
@@ -1,0 +1,3 @@
+// @flow
+
+export default {};


### PR DESCRIPTION
The recent new arch changes broke things for React Native Web.

The web team have indicated that they won't be mocking out TurboModuleRegistry themselves and preference downstream libraries supporting the web. (https://github.com/necolas/react-native-web/pull/2503#issuecomment-1485550206)