### PR TITLE
fix: make `lintVitalAnalyze*` depend on copy

### DIFF
--- a/fonts.gradle
+++ b/fonts.gradle
@@ -26,7 +26,11 @@ afterEvaluate {
 
     android.applicationVariants.all { def variant ->
         def targetName = variant.name.capitalize()
+
         def generateAssetsTask = tasks.findByName("generate${targetName}Assets")
         generateAssetsTask.dependsOn(fontCopyTask)
+
+        def lintVitalAnalyzeTask = tasks.findByName("lintVitalAnalyze${targetName}")
+        lintVitalAnalyzeTask?.dependsOn(fontCopyTask)
     }
 }


### PR DESCRIPTION
Since Gradle 8 (the default as of React Native 0.72), the task dependency resolution appears to be a lot tighter, and so attempting to run:

    npx react-native build-android --tasks assembleRelease

errors out with the following:

    - Gradle detected a problem with the following location: '<project>/android/app/build/intermediates/ReactNativeVectorIcons'.
  
      Reason: Task ':app:lintVitalAnalyzeRelease' uses this output of task ':app:copyReactNativeVectorIconFonts' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed.
  
      Possible solutions:
        1. Declare task ':app:copyReactNativeVectorIconFonts' as an input of ':app:lintVitalAnalyzeRelease'.
        2. Declare an explicit dependency on ':app:copyReactNativeVectorIconFonts' from ':app:lintVitalAnalyzeRelease' using Task#dependsOn. 3. Declare an explicit dependency on ':app:copyReactNativeVectorIconFonts' from ':app:lintVitalAnalyzeRelease' using Task#mustRunAfter.
  
      Please refer to https://docs.gradle.org/8.0.1/userguide/validation_problems.html#implicit_dependency for more details about this problem.


This ensures that any of the `lintVitalAnalyze*` tasks (likely only `lintVitalAnalyzeRelease`) depend on the copy task.