### PR TITLE
fix: filter meta font json from render method

### DIFF
--- a/directory/bin/generate-font-styles.js
+++ b/directory/bin/generate-font-styles.js
@@ -6,6 +6,8 @@ const path = require('path');
 const customFontMap = {
   'FontAwesome5_Solid.ttf': 'FontAwesome5',
   'FontAwesome5_Brands.ttf': 'FontAwesome5Brands',
+  'FontAwesome6_Solid.ttf': 'FontAwesome6',
+  'FontAwesome6_Brands.ttf': 'FontAwesome6Brands',
 };
 
 const fontDirectory = path.resolve(__dirname, '../../Fonts');

--- a/directory/bin/generate-glyphmap-index.js
+++ b/directory/bin/generate-glyphmap-index.js
@@ -35,8 +35,7 @@ const index = fs
   .filter(
     f =>
       path.extname(f) === glypmapExtension &&
-      !f.includes('_meta') &&
-      (!f.startsWith('FontAwesome5') || !f.startsWith('FontAwesome6'))
+      !(f.startsWith('FontAwesome5') || f.startsWith('FontAwesome6'))
   )
   .reduce(
     (acc, file) => {

--- a/directory/bin/generate-glyphmap-index.js
+++ b/directory/bin/generate-glyphmap-index.js
@@ -6,14 +6,24 @@ const path = require('path');
 const glypmapDirectory = path.resolve(__dirname, '../../glyphmaps');
 const glypmapExtension = '.json';
 
-const fontAwesomeGlyphmap = require(path.join(
+const fontAwesome5Glyphmap = require(path.join(
   glypmapDirectory,
   'FontAwesome5Free.json'
 ));
-const fontAwesomeMeta = require(path.join(
+const fontAwesome5Meta = require(path.join(
   glypmapDirectory,
   'FontAwesome5Free_meta.json'
 ));
+
+const fontAwesome6Glyphmap = require(path.join(
+  glypmapDirectory,
+  'FontAwesome6Free.json'
+));
+const fontAwesome6Meta = require(path.join(
+  glypmapDirectory,
+  'FontAwesome6Free_meta.json'
+));
+
 const pickGlyps = (glyps, glyphmap) =>
   glyps.reduce((acc, glyp) => {
     acc[glyp] = glyphmap[glyp];
@@ -22,8 +32,12 @@ const pickGlyps = (glyps, glyphmap) =>
 
 const index = fs
   .readdirSync(glypmapDirectory)
-  .filter(f => path.extname(f) === glypmapExtension)
-  .filter(f => !f.startsWith('FontAwesome5'))
+  .filter(
+    f =>
+      path.extname(f) === glypmapExtension &&
+      !f.includes('_meta') &&
+      (!f.startsWith('FontAwesome5') || !f.startsWith('FontAwesome6'))
+  )
   .reduce(
     (acc, file) => {
       const name = path.basename(file, glypmapExtension);
@@ -31,10 +45,15 @@ const index = fs
       return acc;
     },
     {
-      FontAwesome5: pickGlyps(fontAwesomeMeta.solid, fontAwesomeGlyphmap),
+      FontAwesome5: pickGlyps(fontAwesome5Meta.solid, fontAwesome5Glyphmap),
       FontAwesome5Brands: pickGlyps(
-        fontAwesomeMeta.brands,
-        fontAwesomeGlyphmap
+        fontAwesome5Meta.brands,
+        fontAwesome5Glyphmap
+      ),
+      FontAwesome6: pickGlyps(fontAwesome6Meta.solid, fontAwesome6Glyphmap),
+      FontAwesome6Brands: pickGlyps(
+        fontAwesome6Meta.brands,
+        fontAwesome6Glyphmap
       ),
     }
   );

--- a/directory/src/App.js
+++ b/directory/src/App.js
@@ -1,6 +1,8 @@
+import './App.css';
+
 /* eslint-disable react/prop-types, jsx-a11y/label-has-associated-control */
 import * as React from 'react';
-import './App.css';
+
 import IconFamilies from './generated/glyphmapIndex.json';
 
 const WAITING_INTERVAL = 300;
@@ -67,12 +69,13 @@ const SearchBar = ({ onSubmit }) => {
   );
 };
 
-const renderIcon = (family, name) => (
-  <div className="Result-Icon-Container" key={name}>
-    <Icon family={family} name={name} className="Result-Icon" />
-    <h4 className="Result-Icon-Name">{name}</h4>
-  </div>
-);
+const renderIcon = (family, name) =>
+  family.includes('_meta') ? null : (
+    <div className="Result-Icon-Container" key={name}>
+      <Icon family={family} name={name} className="Result-Icon" />
+      <h4 className="Result-Icon-Name">{name}</h4>
+    </div>
+  );
 
 const renderMatch = match => {
   const { family, names } = match;

--- a/directory/src/App.js
+++ b/directory/src/App.js
@@ -69,13 +69,12 @@ const SearchBar = ({ onSubmit }) => {
   );
 };
 
-const renderIcon = (family, name) =>
-  family.includes('_meta') ? null : (
-    <div className="Result-Icon-Container" key={name}>
-      <Icon family={family} name={name} className="Result-Icon" />
-      <h4 className="Result-Icon-Name">{name}</h4>
-    </div>
-  );
+const renderIcon = (family, name) => (
+  <div className="Result-Icon-Container" key={name}>
+    <Icon family={family} name={name} className="Result-Icon" />
+    <h4 className="Result-Icon-Name">{name}</h4>
+  </div>
+);
 
 const renderMatch = match => {
   const { family, names } = match;


### PR DESCRIPTION
What's the problem:

Library website with icons list stop rendering due an error on render method.

How i resolved:

The problem is the script that generates the glyphmaps, for some reason, the script that merge the files into one map json, is putting _meta json in too, and thats causes an exception on rendering function. I just filter the json property name if there's a family with "_meta" in the name. Probaly the script should be fixed, but I don't know exactly how things work here, so it's a quick solution.