### PR TITLE
Fix for Memory Leak. iOS. RNVectorIconsManager

### DIFF
--- a/RNVectorIconsManager/RNVectorIconsManager.mm
+++ b/RNVectorIconsManager/RNVectorIconsManager.mm
@@ -163,6 +163,9 @@ RCT_EXPORT_METHOD(
       resolve(nil);
     }
 
+    if (errorRef) {
+        CFRelease(errorRef);
+    }
     CFRelease(font);
   }
   if (provider) {


### PR DESCRIPTION
Released errorRef object which is not managed by ARC to fix memory leak
<!-- Describe your environment (OS, target platform, react-native-vector-icons version etc.) -->
## Environment
Xcode 14.3, iOS 16.4 

## Opened issue
https://github.com/oblador/react-native-vector-icons/issues/1499

<!-- Describe what happened, what worked and didn't work as expected -->
## Description

Into `loadFontWithFileName` func we call CTFontManagerRegisterGraphicsFont whitch have parameter with type  CFErrorRef * which is not managed by ARC. 

<img width="995" alt="Screenshot 2023-05-18 at 6 47 16 PM" src="https://github.com/oblador/react-native-vector-icons/assets/36487069/a3802945-a54a-4363-b55c-243e05ed889d">
<img width="1012" alt="Screenshot 2023-05-18 at 6 47 45 PM" src="https://github.com/oblador/react-native-vector-icons/assets/36487069/2cd1f0ee-8c91-4e62-a1b2-5623834cee0f">


## Proposed fix
Proposed fix in RNVectorIconsManager.m:

To avoid memory leak we need to release that errorRef varible after usage.

```
RCT_EXPORT_METHOD(loadFontWithFileName:(NSString *)fontFileName
                  extension:(NSString *)extension
                  resolver:(RCTPromiseResolveBlock)resolve
                  rejecter:(RCTPromiseRejectBlock)reject)
{
  NSBundle *bundle = [NSBundle bundleForClass:[self class]];
  NSURL *fontURL = [bundle URLForResource:fontFileName withExtension:extension];
  NSData *fontData = [NSData dataWithContentsOfURL:fontURL];

  CGDataProviderRef provider = CGDataProviderCreateWithCFData((CFDataRef)fontData);
  CGFontRef font = CGFontCreateWithDataProvider(provider);

  if (font) {
    CFErrorRef errorRef = NULL;
    if (CTFontManagerRegisterGraphicsFont(font, &errorRef) == NO) {
      NSError *error = (__bridge NSError *)errorRef;
      if (error.code == kCTFontManagerErrorAlreadyRegistered) {
        resolve(nil);
      } else {
        reject(@"font_load_failed", @"Font failed to load", error);
      }
    } else {
      resolve(nil);
    }
    if (errorRef) {
        CFRelease(errorRef);
    }
    CFRelease(font);
  }
  if (provider) {
    CFRelease(provider);
  }
} 
```

Here we add 

```
if (errorRef) {         
   CFRelease(errorRef);     
} 
```


<!-- Providing us with a demo of the bug can help if the behaviour is hard to reproduce -->
## Reproducible Demo

Test project with memory leak https://github.com/kuserhii/ReactNativeVectorIconMemoryLeak