### PR TITLE
fix(android): add buildFeatures.buildConfig for AGP8+ compatibility

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,6 +22,10 @@ if (isNewArchitectureEnabled()) {
 
 android {
     namespace = "com.oblador.vectoricons"
+    buildFeatures {
+         buildConfig true
+    }
+
     compileSdkVersion safeExtGet('compileSdkVersion', 31)
 
     defaultConfig {


### PR DESCRIPTION
## Summary

Upcoming react-native 0.73+ includes android gradle plugin 8+ which needs namespace in build.gradle but also needs buildFeatures.buildConfig enabled as well for modules that use it

It is not sufficient to enable this at the top-level app build.gradle, specific modules that use it (such as those that implement new architecture, it seems) must also enable it at the module level

This change was necessary and is in-use in my work app via patch-package as I work through android-gradle-plugin 8+ issues in prep for react-native 0.73 launching for everyone

This change is not backwards compatible but I notice the namespace addition here also is not. So this will not work on android gradle plugin < 7, but neither does the namespace addition. It will work with android gradle plugin 7 though

It is similar to changes I needed to do as react-native-firebase maintainer --> https://github.com/invertase/react-native-firebase/commit/b52d0ce6723c077190618641ce0f33ced9fd4090

## Test Plan

### What's required for testing (prerequisites)?

With apologies, you have to alter an app that integrates this module to use android gradle plugin 8, it's difficult to do that in repos I'm proposing these changes in because bumping to android gradle plugin 8 requries a large amount of transitive dependency changes in CI

I have integrated this in an app and tested it, and done similar work as maintainer of react-native-firebase, react-native-netinfo and react-native-device-info, and I'm now pushing these out to the repos

### What are the steps to reproduce (after prerequisites)?

run the build for android