### PR TITLE
fix(fonts.gradle): fix react native 0.73 build errors

### DIFF
--- a/fonts.gradle
+++ b/fonts.gradle
@@ -31,6 +31,11 @@ afterEvaluate {
         if (lintVitalAnalyzeTask) {
         lintVitalAnalyzeTask.dependsOn(fontCopyTask)
         }
+
+        def generateReportTask = tasks.findByName("generate${targetName}LintVitalReportModel")
+        if (generateReportTask) {
+            generateReportTask.dependsOn(fontCopyTask)
+        }
       
         def generateAssetsTask = tasks.findByName("generate${targetName}Assets")
         generateAssetsTask.dependsOn(fontCopyTask)


### PR DESCRIPTION
Fix build errors on react native 0.73.x version.

This is similar to a previous fix done for 0.72
https://github.com/oblador/react-native-vector-icons/issues/1508#issuecomment-1606108215

Commit details: https://github.com/oblador/react-native-vector-icons/commit/e9cc5898a4331f5f9b9e03e3f5345c5cda3ebf61