### PR TITLE
added visionos support

### DIFF
--- a/RNVectorIcons.podspec
+++ b/RNVectorIcons.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.homepage       = package["homepage"]
   s.license        = package["license"]
   s.author         = { package["author"]["name"] => package["author"]["email"] }
-  s.platforms      = { :ios => "12.0", :tvos => "9.0" }
+  s.platforms      = { :ios => "12.0", :tvos => "9.0" ,:visionos => "1.0"}
   s.source         = { :git => package["repository"]["url"], :tag => "v#{s.version}" }
 
   s.source_files   = 'RNVectorIconsManager/**/*.{h,m,mm,swift}'


### PR DESCRIPTION
This PR adds support for vision os

https://github.com/oblador/react-native-vector-icons/assets/42144106/5ecb6a8a-6f04-4a75-9c94-ab3f8b7c9042


Test plan:
1. create new visionos app using `npx @callstack/react-native-visionos init MyApp`
2. add react-native-vector-icons
3. Test if it works