### PR TITLE
fix/rn-0.73-lint-analyze-dep-fonts.gradle

### DIFF
--- a/fonts.gradle
+++ b/fonts.gradle
@@ -27,11 +27,17 @@ afterEvaluate {
     android.applicationVariants.all { def variant ->
         def targetName = variant.name.capitalize()
         def lintVitalAnalyzeTask = tasks.findByName("lintVitalAnalyze${targetName}")
-      
+
         if (lintVitalAnalyzeTask) {
         lintVitalAnalyzeTask.dependsOn(fontCopyTask)
         }
-      
+
+        def lintAnalyzeTask = tasks.findByName("lintAnalyze${targetName}")
+
+        if (lintAnalyzeTask) {
+        lintAnalyzeTask.dependsOn(fontCopyTask)
+        }
+
         def generateAssetsTask = tasks.findByName("generate${targetName}Assets")
         generateAssetsTask.dependsOn(fontCopyTask)
       }

--- a/fonts.gradle
+++ b/fonts.gradle
@@ -27,13 +27,11 @@ afterEvaluate {
     android.applicationVariants.all { def variant ->
         def targetName = variant.name.capitalize()
         def lintVitalAnalyzeTask = tasks.findByName("lintVitalAnalyze${targetName}")
-
         if (lintVitalAnalyzeTask) {
         lintVitalAnalyzeTask.dependsOn(fontCopyTask)
         }
 
         def lintAnalyzeTask = tasks.findByName("lintAnalyze${targetName}")
-
         if (lintAnalyzeTask) {
         lintAnalyzeTask.dependsOn(fontCopyTask)
         }


### PR DESCRIPTION
almost the same as https://github.com/oblador/react-native-vector-icons/pull/1585

Build log:
```log
FAILURE: Build failed with an exception.

* What went wrong:
A problem was found with the configuration of task ':app:lintAnalyzeDebug' (type 'AndroidLintAnalysisTask').
  - Gradle detected a problem with the following location: '/Users/runner/work/1/s/android/app/build/intermediates/ReactNativeVectorIcons'.
    
    Reason: Task ':app:lintAnalyzeDebug' uses this output of task ':app:copyReactNativeVectorIconFonts' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed.
    
    Possible solutions:
      1. Declare task ':app:copyReactNativeVectorIconFonts' as an input of ':app:lintAnalyzeDebug'.
      2. Declare an explicit dependency on ':app:copyReactNativeVectorIconFonts' from ':app:lintAnalyzeDebug' using Task#dependsOn.
      3. Declare an explicit dependency on ':app:copyReactNativeVectorIconFonts' from ':app:lintAnalyzeDebug' using Task#mustRunAfter.
    
    For more information, please refer to https://docs.gradle.org/8.3/userguide/validation_problems.html#implicit_dependency in the Gradle documentation.

```