### PR TITLE
README: add info regarding 'pod update' necessary for iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,11 @@ To set up the library on your macOS project using `react-native-macos`, follow t
 
 2. Edit your `Info.plist` and include a new property named **Application fonts resource path** (or `ATSApplicationFontsPath` if Xcode's autocomplete isn't functioning or you're not using Xcode). Set the value of this property to `Fonts`.
 
+3. Update the pod. From your project's `/ios` folder run:
+```sh
+pod update
+```
+   
 _Please note that after adding new fonts, you need to recompile your project. Also, make sure that the `Fonts` folder is present under the **Copy Bundle Resources** section within the **Build Phases** of your Xcode project._
 
 These steps will effectively integrate the vector icons library into your macOS project while utilizing the `react-native-macos` framework.

--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ To set up the library on your macOS project using `react-native-macos`, follow t
 
 2. Edit your `Info.plist` and include a new property named **Application fonts resource path** (or `ATSApplicationFontsPath` if Xcode's autocomplete isn't functioning or you're not using Xcode). Set the value of this property to `Fonts`.
 
-3. Update the pod. From your project's `/ios` folder run:
+3. From your project's `/ios` folder run:
 ```sh
 bundle exec pod install
 ```

--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ To set up the library on your macOS project using `react-native-macos`, follow t
 
 3. Update the pod. From your project's `/ios` folder run:
 ```sh
-pod update
+bundle exec pod install
 ```
    
 _Please note that after adding new fonts, you need to recompile your project. Also, make sure that the `Fonts` folder is present under the **Copy Bundle Resources** section within the **Build Phases** of your Xcode project._


### PR DESCRIPTION
For iOS it was crucial for me to run a "pod update" in the /ios folder to propagate the changes to the Info.plist and the addition of the fonts. The app could not find the fonts otherwise.

The README does not mention this, I had to look around to find instructions on other sites providing this info.