### PR TITLE
add dependency between lintAnalyze and fontCopyTask

### DIFF
--- a/fonts.gradle
+++ b/fonts.gradle
@@ -31,6 +31,12 @@ afterEvaluate {
         if (lintVitalAnalyzeTask) {
         lintVitalAnalyzeTask.dependsOn(fontCopyTask)
         }
+
+        def lintAnalyzeTask = tasks.findByName("lintAnalyze${targetName}")
+      
+        if (lintAnalyzeTask) {
+        lintAnalyzeTask.dependsOn(fontCopyTask)
+        }
       
         def generateAssetsTask = tasks.findByName("generate${targetName}Assets")
         generateAssetsTask.dependsOn(fontCopyTask)


### PR DESCRIPTION
Fix for the following error message:

A problem was found with the configuration of task ':app:lintAnalyzeDebug' (type 'AndroidLintAnalysisTask').
  - Gradle detected a problem with the following location: '/Users/xxx/src/xxx/xxx/android/app/build/intermediates/ReactNativeVectorIcons'.
    
    Reason: Task ':app:lintAnalyzeDebug' uses this output of task ':app:copyReactNativeVectorIconFonts' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed.