### PR TITLE
Fixes monorepo Android Build if only `@react-native-vector-icons/common` is Installed

### DIFF
--- a/packages/common/android/build.gradle
+++ b/packages/common/android/build.gradle
@@ -119,7 +119,7 @@ task copyFonts(type: Exec) {
   standardOutput = fonts
 
   doLast {
-    def files = fonts.toString().trim().split('\n')
+    def files = fonts.toString().trim().split('\n').findAll { it }
     copy {
       from files
 


### PR DESCRIPTION
Currently, building an Android App with the `@react-native-vector-icons/common` `0.0.1-alpha.6` package installed fails with the following error if no icon package is installed:

```
Execution failed for task ':react-native-vector-icons_common:copyFonts'.
> path may not be null or empty string. path=''
```

This PR filters out empty strings in `build.gradle`'s `copyFonts` task, which fixes the issue.