### PR TITLE
docs: remove unnecessary ios install steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,11 +69,7 @@ Should you find this library beneficial, kindly contemplate the option of [spons
 3.  If you're planning to use FontAwesome 5 or 6 icons, refer to these guides: [FontAwesome 5](FONTAWESOME5.md) | [FontAwesome 6](FONTAWESOME6.md)
 
 ### iOS Setup
-To use the bundled icons on iOS, follow these steps:
-
-- Navigate to `node_modules/react-native-vector-icons` and drag the `Fonts` folder (or select specific fonts) into your Xcode project.
-  - Make sure your app is checked under "Add to targets," and if adding the whole folder, check "Create groups."
-  - Not familiar with Xcode? Check out this [article](https://medium.com/@vimniky/how-to-use-vector-icons-in-your-react-native-project-8212ac6a8f06).
+To use the bundled icons on iOS, perform the following step:
 
 - Edit `Info.plist` and add a property called **Fonts provided by application** (or **UIAppFonts** if Xcode autocomplete is not working):
   - <details><summary>List of all available fonts to copy & paste in Info.plist</summary>
@@ -109,26 +105,7 @@ To use the bundled icons on iOS, follow these steps:
 
   ![XCode screenshot](https://cloud.githubusercontent.com/assets/378279/12421498/2db1f93a-be88-11e5-89c8-2e563ba6251a.png)
 
-- In Xcode, select your project in the navigator, choose your app's target, go to the **Build Phases** tab, and under **Copy Bundle Resources**, add the copied fonts.
-
-- When using auto linking, it will automatically add all fonts to the **Build Phases**, **Copy Pods Resources**. Which will end up in your bundle.
-  To avoid that, create a `react-native.config.js` file at the root of your react-native project with:
-  
-  ```javascript
-    module.exports = {
-      dependencies: {
-        'react-native-vector-icons': {
-          platforms: {
-            ios: null,
-          },
-        },
-      },
-    };
-    ```
-
 _Note: Recompile your project after adding new fonts._
-
-_Note 2: If you're getting problems with `duplicate outputs file` for fonts on ios build, try running `cd ios && pod install` after the `react-native.config.js` configuration._
 
 ### Android Setup
 


### PR DESCRIPTION
Hi and thanks for maintaining this popular library!

This PR attempts to clear up the installation instructions for iOS.

The instructions currently say that a [manual step is needed](https://github.com/oblador/react-native-vector-icons?tab=readme-ov-file#ios-setup), but I haven't found it to be necessary. In fact, when I follow the "iOS Setup" I get an error `Multiple commands produce '.../iconsdemo.app/FontAwesome6_Regular.ttf'` 

Only the last bullet point mentions that if you use autolinking (which almost everybody does), it will automatically add all fonts - so the manual adding of files to Xcode isn't needed.

Then there's this:

> Note 2: If you're getting problems with duplicate outputs file for fonts on ios build, try running cd ios && pod install after the react-native.config.js configuration.

However, the correct approach would be to not "Navigate to node_modules/react-native-vector-icons and drag the Fonts folder (or select specific fonts) into your Xcode project." and "In Xcode, select your project in the navigator, choose your app's target, go to the Build Phases tab, and under Copy Bundle Resources, add the copied fonts." in the first place. The only necessary step is to add fonts to `Info.plist`.

Please feel free to organize the instructions differently, this is mostly me pointing out that there's potential for more clarity. 

Thank you :) 
