### PR TITLE
fix(icon-explorer@android): make android build work with detox

### DIFF
--- a/packages/icon-explorer/android/build.gradle
+++ b/packages/icon-explorer/android/build.gradle
@@ -51,7 +51,7 @@ allprojects {
         def androidExtension = project.extensions.findByName('android')
         if (androidExtension != null && project.name == 'app') {
             androidExtension.defaultConfig {
-                // testBuildType System.getProperty('testBuildType', 'debug')
+                androidExtension.testBuildType System.getProperty('testBuildType', 'debug')
                 testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
 
                 ndk {


### PR DESCRIPTION
With this PRs icon-explorer should be buildable and testable with detox on android in monorepo branch

- set testBuildType in androidExtension directly (without this androidTest will only build debug so it need to set testBinaryPath)