### PR TITLE
Crash fix on iOS 17 and Xcode15 due to deprecated graphics API

### DIFF
--- a/RNVectorIconsManager/RNVectorIconsManager.mm
+++ b/RNVectorIconsManager/RNVectorIconsManager.mm
@@ -64,11 +64,10 @@ RCT_EXPORT_MODULE(RNVectorIcons);
     NSAttributedString *attributedString = [[NSAttributedString alloc] initWithString:glyph attributes:@{NSFontAttributeName: font, NSForegroundColorAttributeName: color}];
 
     CGSize iconSize = [attributedString size];
-    UIGraphicsBeginImageContextWithOptions(iconSize, NO, 0.0);
-    [attributedString drawAtPoint:CGPointMake(0, 0)];
-
-    UIImage *iconImage = UIGraphicsGetImageFromCurrentImageContext();
-    UIGraphicsEndImageContext();
+    UIGraphicsImageRenderer *renderer = [[UIGraphicsImageRenderer alloc] initWithSize:iconSize];
+    UIImage *iconImage = [renderer imageWithActions:^(UIGraphicsImageRendererContext * _Nonnull rendererContext) {
+      [attributedString drawAtPoint:CGPointMake(0, 0)];
+    }];
 
     NSData *imageData = UIImagePNGRepresentation(iconImage);
     return [imageData writeToFile:filePath atomically:YES];


### PR DESCRIPTION
This PR fixes a crash which is happens on apps built on iOS 17 using Xcode15 due to deprecation of UIGraphicsBeginImageContextWithOptions.

This PR addresses the following issue - https://github.com/oblador/react-native-vector-icons/issues/1575

Reference - https://developer.apple.com/documentation/uikit/1623912-uigraphicsbeginimagecontextwitho