### PR TITLE
chore: add bug report form

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,20 +1,47 @@
----
-name: Bug report
-about: Create a report to help us improve
+name: "\U0001F41B Bug Report"
+description: 'Report a reproducible bug in the react-native-vector-icons package'
+body:
+  - type: markdown
+    attributes:
+      value: Thanks for taking the time to file a bug report! Please fill out this entire form.
+  - type: checkboxes
+    attributes:
+      label: I have searched open and closed issues for this issue.
+      options:
+        - label: I have searched open and closed issues.
+          required: true
+  - type: input
+    attributes:
+      label: Minimal reproducible example
+      description: |
+        A link to a GitHub repository containing a minimal reproducible example. This repository should include as little code as possible and not include extraneous dependencies.
 
----
-
-<!-- Requirements: please go through this checklist before opening a new issue -->
-  - [ ] Review the documentation: https://github.com/oblador/react-native-vector-icons
-  - [ ] Search for existing issues (including closed issues): https://github.com/oblador/react-native-vector-icons/issues
-
-<!-- Describe your environment (OS, target platform, react-native-vector-icons version etc.) -->
-## Environment
-
-<!-- Describe what happened, what worked and didn't work as expected -->
-## Description
-Describe your issue in detail. Include screenshots if needed.
-
-<!-- Providing us with a demo of the bug can help if the behaviour is hard to reproduce -->
-## Reproducible Demo
-Let us know how to reproduce the issue. Include a code sample, share a project, or share an app that reproduces the issue using https://snack.expo.io/. Please follow the guidelines for providing a MCVE: https://stackoverflow.com/help/mcve
+        If a reproducible example is not provided, your issue may be closed.
+        [Learn more about creating a minimal reproducible example](https://stackoverflow.com/help/mcve).
+    validations:
+      required: true
+  - type: dropdown
+    attributes:
+      label: What platform(s) does this occur on?
+      multiple: true
+      options:
+        - Android
+        - iOS
+        - web
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Summary
+      description: |
+        Explain the steps we need to take to reproduce the issue. Include a video or screenshots if you think it may help.
+        Clearly describe what the expected behavior is and what instead is actually happening. Be concise and precise in your description. Include the affected platforms.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      render: text
+      label: Your computer environment
+      description: Run the `npx react-native info` command and paste its output in the field below.
+    validations:
+      required: true


### PR DESCRIPTION
Hi!
This is an extremely popular repo that many rely on.

This is reflected in the frequency with which people open issues here.

However, I noticed many of the issues are lacking the information which is necessary to resolve the issues effectively. This puts strain on maintainer(s) because they need to spend valuable time guessing what went wrong and reproducing a reported issue. 

The main thing this PR changes is that it makes it a requirement to add a runnable repro when an issue is being opened. You can see how the form would look [here](https://github.com/react-native-google-signin/google-signin/issues/new?assignees=&labels=&projects=&template=custom.yaml).

This will help to increase the quality of the reported issues, and make them more actionable by the community and maintainers alike. It also helps to preserve maintainer mental health (😄).

Note that this doesn't stop people from opening issues without reproductions. The next step, potentially, can be integrating something like [this](https://github.com/react-native-google-signin/google-signin/blob/master/.github/workflows/support.yml) which can be used [like this](https://github.com/react-native-google-signin/google-signin/issues/1311) - up to the maintainers.

cc @johnf 