### PR TITLE
fix: warn if glyph does not exist for default IconStyle.

### DIFF
--- a/packages/fontawesome-common/generators/app/templates/src/index.tsx
+++ b/packages/fontawesome-common/generators/app/templates/src/index.tsx
@@ -45,6 +45,9 @@ type Props =
 const Icon = (props: Props) => {
   const { iconStyle, name } = props;
   if (!iconStyle) {
+    if (!glyphValidator(name, 'regular')) {
+      console.warn(`noSuchGlyph: glyph ${String(name)} does not exist for 'regular' icon type for <%= className %>`);
+    }
     return <<%= upperDefaultStyleName %>Icon {...props} />;
   }
 

--- a/packages/fontawesome5-pro/src/index.tsx
+++ b/packages/fontawesome5-pro/src/index.tsx
@@ -52,6 +52,9 @@ type Props =
 const Icon = (props: Props) => {
   const { iconStyle, name } = props;
   if (!iconStyle) {
+    if (!glyphValidator(name, 'regular')) {
+      console.warn(`noSuchGlyph: glyph ${String(name)} does not exist for 'regular' icon type for FontAwesome5Pro`);
+    }
     return <RegularIcon {...props} />;
   }
 

--- a/packages/fontawesome5/src/index.tsx
+++ b/packages/fontawesome5/src/index.tsx
@@ -44,6 +44,9 @@ type Props =
 const Icon = (props: Props) => {
   const { iconStyle, name } = props;
   if (!iconStyle) {
+    if (!glyphValidator(name, 'regular')) {
+      console.warn(`noSuchGlyph: glyph ${String(name)} does not exist for 'regular' icon type for FontAwesome5`);
+    }
     return <RegularIcon {...props} />;
   }
 

--- a/packages/fontawesome6-pro/src/index.tsx
+++ b/packages/fontawesome6-pro/src/index.tsx
@@ -72,6 +72,9 @@ type Props =
 const Icon = (props: Props) => {
   const { iconStyle, name } = props;
   if (!iconStyle) {
+    if (!glyphValidator(name, 'regular')) {
+      console.warn(`noSuchGlyph: glyph ${String(name)} does not exist for 'regular' icon type for FontAwesome6Pro`);
+    }
     return <RegularIcon {...props} />;
   }
 

--- a/packages/fontawesome6/src/index.tsx
+++ b/packages/fontawesome6/src/index.tsx
@@ -44,6 +44,9 @@ type Props =
 const Icon = (props: Props) => {
   const { iconStyle, name } = props;
   if (!iconStyle) {
+    if (!glyphValidator(name, 'regular')) {
+      console.warn(`noSuchGlyph: glyph ${String(name)} does not exist for 'regular' icon type for FontAwesome6`);
+    }
     return <RegularIcon {...props} />;
   }
 


### PR DESCRIPTION
Previously, validation only ran when an iconStyle was specified.
This adds validation for the default iconStyle, ensuring it runs even when no specific style is provided.

For Example "truck" icon in fontawesome5 doesn't exist in regular and only solid.