### PR TITLE
Fix Gradle task dependency (include lintAnalyze)

### DIFF
--- a/fonts.gradle
+++ b/fonts.gradle
@@ -24,20 +24,22 @@ afterEvaluate {
         }
     }
 
-    android.applicationVariants.all { def variant ->
-        def targetName = variant.name.capitalize()
-        def lintVitalAnalyzeTask = tasks.findByName("lintVitalAnalyze${targetName}")
-      
-        if (lintVitalAnalyzeTask) {
-        lintVitalAnalyzeTask.dependsOn(fontCopyTask)
-        }
+    android.applicationVariants.all { variant ->
+        def variantName = variant.name.capitalize()
+        def taskNames = [
+                "generate${variantName}Assets",
+                "generate${variantName}LintModel",
+                "generate${variantName}LintReportModel",
+                "generate${variantName}LintVitalReportModel",
+                "lintAnalyze${variantName}",
+                "lintVitalAnalyze${variantName}",
+        ]
 
-        def generateReportTask = tasks.findByName("generate${targetName}LintVitalReportModel")
-        if (generateReportTask) {
-            generateReportTask.dependsOn(fontCopyTask)
+        taskNames.each { taskName ->
+            def task = tasks.findByName(taskName)
+            if (task) {
+                task.dependsOn(fontCopyTask)
+            }
         }
-      
-        def generateAssetsTask = tasks.findByName("generate${targetName}Assets")
-        generateAssetsTask.dependsOn(fontCopyTask)
-      }
+    }
 }


### PR DESCRIPTION
I had an error with a build (RN 0.73, Gradle 8.3, react-native-vector-icons 10.2.0):

```
FAILURE: Build failed with an exception.

* What went wrong:
A problem was found with the configuration of task ':app:lintAnalyzeDebug' (type 'AndroidLintAnalysisTask').
  - Gradle detected a problem with the following location: '/path/to/android/app/build/intermediates/ReactNativeVectorIcons'.

    Reason: Task ':app:lintAnalyzeDebug' uses this output of task ':app:copyReactNativeVectorIconFonts' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed.

    Possible solutions:
      1. Declare task ':app:copyReactNativeVectorIconFonts' as an input of ':app:lintAnalyzeDebug'.
      2. Declare an explicit dependency on ':app:copyReactNativeVectorIconFonts' from ':app:lintAnalyzeDebug' using Task#dependsOn.
      3. Declare an explicit dependency on ':app:copyReactNativeVectorIconFonts' from ':app:lintAnalyzeDebug' using Task#mustRunAfter.

    For more information, please refer to https://docs.gradle.org/8.3/userguide/validation_problems.html#implicit_dependency in the Gradle documentation.
```

After some digging, I found a similar error related to `lintVitalAnalyze` (addressed in #1515 and #1577).
Notice how this error is different (`lintAnalyze`, not `lintVitalAnalyze`).

Related discussions: #1508 #1588

The issue was resolved by also including `lintAnalyze` in the tasks that depend on the font copy task (there were already three other similar tasks in `fonts.gradle`).

I consolidated task names into a list and iterate through them to set dependencies. This reduces redundancy and improves maintainability. It also fixes a couple minor whitespace errors and indentation issues on those same lines.