### PR TITLE
fix(template): try to use root project's compile sdk to avoid aar metadata incompatablity

### DIFF
--- a/packages/ant-design/android/build.gradle
+++ b/packages/ant-design/android/build.gradle
@@ -5,6 +5,10 @@ def isNewArchitectureEnabled() {
   return rootProject.hasProperty("newArchEnabled") && rootProject.getProperty("newArchEnabled") == "true"
 }
 
+def safeExtGet(prop, fallback) {
+  rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 apply plugin: "com.android.library"
 apply plugin: "kotlin-android"
 
@@ -32,7 +36,7 @@ android {
     }
   }
 
-  compileSdkVersion 31
+  compileSdkVersion safeExtGet('compileSdkVersion', 31)
 }
 
 dependencies {

--- a/packages/entypo/android/build.gradle
+++ b/packages/entypo/android/build.gradle
@@ -5,6 +5,10 @@ def isNewArchitectureEnabled() {
   return rootProject.hasProperty("newArchEnabled") && rootProject.getProperty("newArchEnabled") == "true"
 }
 
+def safeExtGet(prop, fallback) {
+  rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 apply plugin: "com.android.library"
 apply plugin: "kotlin-android"
 
@@ -32,7 +36,7 @@ android {
     }
   }
 
-  compileSdkVersion 31
+  compileSdkVersion safeExtGet('compileSdkVersion', 31)
 }
 
 dependencies {

--- a/packages/evil-icons/android/build.gradle
+++ b/packages/evil-icons/android/build.gradle
@@ -5,6 +5,10 @@ def isNewArchitectureEnabled() {
   return rootProject.hasProperty("newArchEnabled") && rootProject.getProperty("newArchEnabled") == "true"
 }
 
+def safeExtGet(prop, fallback) {
+  rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 apply plugin: "com.android.library"
 apply plugin: "kotlin-android"
 
@@ -32,7 +36,7 @@ android {
     }
   }
 
-  compileSdkVersion 31
+  compileSdkVersion safeExtGet('compileSdkVersion', 31)
 }
 
 dependencies {

--- a/packages/feather/android/build.gradle
+++ b/packages/feather/android/build.gradle
@@ -5,6 +5,10 @@ def isNewArchitectureEnabled() {
   return rootProject.hasProperty("newArchEnabled") && rootProject.getProperty("newArchEnabled") == "true"
 }
 
+def safeExtGet(prop, fallback) {
+  rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 apply plugin: "com.android.library"
 apply plugin: "kotlin-android"
 
@@ -32,7 +36,7 @@ android {
     }
   }
 
-  compileSdkVersion 31
+  compileSdkVersion safeExtGet('compileSdkVersion', 31)
 }
 
 dependencies {

--- a/packages/fontawesome/android/build.gradle
+++ b/packages/fontawesome/android/build.gradle
@@ -5,6 +5,10 @@ def isNewArchitectureEnabled() {
   return rootProject.hasProperty("newArchEnabled") && rootProject.getProperty("newArchEnabled") == "true"
 }
 
+def safeExtGet(prop, fallback) {
+  rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 apply plugin: "com.android.library"
 apply plugin: "kotlin-android"
 
@@ -32,7 +36,7 @@ android {
     }
   }
 
-  compileSdkVersion 31
+  compileSdkVersion safeExtGet('compileSdkVersion', 31)
 }
 
 dependencies {

--- a/packages/fontawesome5-pro/android/build.gradle
+++ b/packages/fontawesome5-pro/android/build.gradle
@@ -5,6 +5,10 @@ def isNewArchitectureEnabled() {
   return rootProject.hasProperty("newArchEnabled") && rootProject.getProperty("newArchEnabled") == "true"
 }
 
+def safeExtGet(prop, fallback) {
+  rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 apply plugin: "com.android.library"
 apply plugin: "kotlin-android"
 
@@ -32,7 +36,7 @@ android {
     }
   }
 
-  compileSdkVersion 31
+  compileSdkVersion safeExtGet('compileSdkVersion', 31)
 }
 
 dependencies {

--- a/packages/fontawesome5/android/build.gradle
+++ b/packages/fontawesome5/android/build.gradle
@@ -5,6 +5,10 @@ def isNewArchitectureEnabled() {
   return rootProject.hasProperty("newArchEnabled") && rootProject.getProperty("newArchEnabled") == "true"
 }
 
+def safeExtGet(prop, fallback) {
+  rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 apply plugin: "com.android.library"
 apply plugin: "kotlin-android"
 
@@ -32,7 +36,7 @@ android {
     }
   }
 
-  compileSdkVersion 31
+  compileSdkVersion safeExtGet('compileSdkVersion', 31)
 }
 
 dependencies {

--- a/packages/fontawesome6-pro/android/build.gradle
+++ b/packages/fontawesome6-pro/android/build.gradle
@@ -5,6 +5,10 @@ def isNewArchitectureEnabled() {
   return rootProject.hasProperty("newArchEnabled") && rootProject.getProperty("newArchEnabled") == "true"
 }
 
+def safeExtGet(prop, fallback) {
+  rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 apply plugin: "com.android.library"
 apply plugin: "kotlin-android"
 
@@ -32,7 +36,7 @@ android {
     }
   }
 
-  compileSdkVersion 31
+  compileSdkVersion safeExtGet('compileSdkVersion', 31)
 }
 
 dependencies {

--- a/packages/fontawesome6/android/build.gradle
+++ b/packages/fontawesome6/android/build.gradle
@@ -5,6 +5,10 @@ def isNewArchitectureEnabled() {
   return rootProject.hasProperty("newArchEnabled") && rootProject.getProperty("newArchEnabled") == "true"
 }
 
+def safeExtGet(prop, fallback) {
+  rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 apply plugin: "com.android.library"
 apply plugin: "kotlin-android"
 
@@ -32,7 +36,7 @@ android {
     }
   }
 
-  compileSdkVersion 31
+  compileSdkVersion safeExtGet('compileSdkVersion', 31)
 }
 
 dependencies {

--- a/packages/fontello/android/build.gradle
+++ b/packages/fontello/android/build.gradle
@@ -5,6 +5,10 @@ def isNewArchitectureEnabled() {
   return rootProject.hasProperty("newArchEnabled") && rootProject.getProperty("newArchEnabled") == "true"
 }
 
+def safeExtGet(prop, fallback) {
+  rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 apply plugin: "com.android.library"
 apply plugin: "kotlin-android"
 
@@ -32,7 +36,7 @@ android {
     }
   }
 
-  compileSdkVersion 31
+  compileSdkVersion safeExtGet('compileSdkVersion', 31)
 }
 
 dependencies {

--- a/packages/fontisto/android/build.gradle
+++ b/packages/fontisto/android/build.gradle
@@ -5,6 +5,10 @@ def isNewArchitectureEnabled() {
   return rootProject.hasProperty("newArchEnabled") && rootProject.getProperty("newArchEnabled") == "true"
 }
 
+def safeExtGet(prop, fallback) {
+  rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 apply plugin: "com.android.library"
 apply plugin: "kotlin-android"
 
@@ -32,7 +36,7 @@ android {
     }
   }
 
-  compileSdkVersion 31
+  compileSdkVersion safeExtGet('compileSdkVersion', 31)
 }
 
 dependencies {

--- a/packages/foundation/android/build.gradle
+++ b/packages/foundation/android/build.gradle
@@ -5,6 +5,10 @@ def isNewArchitectureEnabled() {
   return rootProject.hasProperty("newArchEnabled") && rootProject.getProperty("newArchEnabled") == "true"
 }
 
+def safeExtGet(prop, fallback) {
+  rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 apply plugin: "com.android.library"
 apply plugin: "kotlin-android"
 
@@ -32,7 +36,7 @@ android {
     }
   }
 
-  compileSdkVersion 31
+  compileSdkVersion safeExtGet('compileSdkVersion', 31)
 }
 
 dependencies {

--- a/packages/generator-react-native-vector-icons/src/app/templates/android/build.gradle
+++ b/packages/generator-react-native-vector-icons/src/app/templates/android/build.gradle
@@ -5,6 +5,10 @@ def isNewArchitectureEnabled() {
   return rootProject.hasProperty("newArchEnabled") && rootProject.getProperty("newArchEnabled") == "true"
 }
 
+def safeExtGet(prop, fallback) {
+  rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 apply plugin: "com.android.library"
 apply plugin: "kotlin-android"
 
@@ -32,7 +36,7 @@ android {
     }
   }
 
-  compileSdkVersion 31
+  compileSdkVersion safeExtGet('compileSdkVersion', 31)
 }
 
 dependencies {

--- a/packages/icomoon/android/build.gradle
+++ b/packages/icomoon/android/build.gradle
@@ -5,6 +5,10 @@ def isNewArchitectureEnabled() {
   return rootProject.hasProperty("newArchEnabled") && rootProject.getProperty("newArchEnabled") == "true"
 }
 
+def safeExtGet(prop, fallback) {
+  rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 apply plugin: "com.android.library"
 apply plugin: "kotlin-android"
 
@@ -32,7 +36,7 @@ android {
     }
   }
 
-  compileSdkVersion 31
+  compileSdkVersion safeExtGet('compileSdkVersion', 31)
 }
 
 dependencies {

--- a/packages/ionicons/android/build.gradle
+++ b/packages/ionicons/android/build.gradle
@@ -5,6 +5,10 @@ def isNewArchitectureEnabled() {
   return rootProject.hasProperty("newArchEnabled") && rootProject.getProperty("newArchEnabled") == "true"
 }
 
+def safeExtGet(prop, fallback) {
+  rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 apply plugin: "com.android.library"
 apply plugin: "kotlin-android"
 
@@ -32,7 +36,7 @@ android {
     }
   }
 
-  compileSdkVersion 31
+  compileSdkVersion safeExtGet('compileSdkVersion', 31)
 }
 
 dependencies {

--- a/packages/lucide/android/build.gradle
+++ b/packages/lucide/android/build.gradle
@@ -5,6 +5,10 @@ def isNewArchitectureEnabled() {
   return rootProject.hasProperty("newArchEnabled") && rootProject.getProperty("newArchEnabled") == "true"
 }
 
+def safeExtGet(prop, fallback) {
+  rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 apply plugin: "com.android.library"
 apply plugin: "kotlin-android"
 
@@ -32,7 +36,7 @@ android {
     }
   }
 
-  compileSdkVersion 31
+  compileSdkVersion safeExtGet('compileSdkVersion', 31)
 }
 
 dependencies {

--- a/packages/material-design-icons/android/build.gradle
+++ b/packages/material-design-icons/android/build.gradle
@@ -5,6 +5,10 @@ def isNewArchitectureEnabled() {
   return rootProject.hasProperty("newArchEnabled") && rootProject.getProperty("newArchEnabled") == "true"
 }
 
+def safeExtGet(prop, fallback) {
+  rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 apply plugin: "com.android.library"
 apply plugin: "kotlin-android"
 
@@ -32,7 +36,7 @@ android {
     }
   }
 
-  compileSdkVersion 31
+  compileSdkVersion safeExtGet('compileSdkVersion', 31)
 }
 
 dependencies {

--- a/packages/material-icons/android/build.gradle
+++ b/packages/material-icons/android/build.gradle
@@ -5,6 +5,10 @@ def isNewArchitectureEnabled() {
   return rootProject.hasProperty("newArchEnabled") && rootProject.getProperty("newArchEnabled") == "true"
 }
 
+def safeExtGet(prop, fallback) {
+  rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 apply plugin: "com.android.library"
 apply plugin: "kotlin-android"
 
@@ -32,7 +36,7 @@ android {
     }
   }
 
-  compileSdkVersion 31
+  compileSdkVersion safeExtGet('compileSdkVersion', 31)
 }
 
 dependencies {

--- a/packages/octicons/android/build.gradle
+++ b/packages/octicons/android/build.gradle
@@ -5,6 +5,10 @@ def isNewArchitectureEnabled() {
   return rootProject.hasProperty("newArchEnabled") && rootProject.getProperty("newArchEnabled") == "true"
 }
 
+def safeExtGet(prop, fallback) {
+  rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 apply plugin: "com.android.library"
 apply plugin: "kotlin-android"
 
@@ -32,7 +36,7 @@ android {
     }
   }
 
-  compileSdkVersion 31
+  compileSdkVersion safeExtGet('compileSdkVersion', 31)
 }
 
 dependencies {

--- a/packages/simple-line-icons/android/build.gradle
+++ b/packages/simple-line-icons/android/build.gradle
@@ -5,6 +5,10 @@ def isNewArchitectureEnabled() {
   return rootProject.hasProperty("newArchEnabled") && rootProject.getProperty("newArchEnabled") == "true"
 }
 
+def safeExtGet(prop, fallback) {
+  rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 apply plugin: "com.android.library"
 apply plugin: "kotlin-android"
 
@@ -32,7 +36,7 @@ android {
     }
   }
 
-  compileSdkVersion 31
+  compileSdkVersion safeExtGet('compileSdkVersion', 31)
 }
 
 dependencies {

--- a/packages/zocial/android/build.gradle
+++ b/packages/zocial/android/build.gradle
@@ -5,6 +5,10 @@ def isNewArchitectureEnabled() {
   return rootProject.hasProperty("newArchEnabled") && rootProject.getProperty("newArchEnabled") == "true"
 }
 
+def safeExtGet(prop, fallback) {
+  rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 apply plugin: "com.android.library"
 apply plugin: "kotlin-android"
 
@@ -32,7 +36,7 @@ android {
     }
   }
 
-  compileSdkVersion 31
+  compileSdkVersion safeExtGet('compileSdkVersion', 31)
 }
 
 dependencies {


### PR DESCRIPTION
Try to use root project's compileSdk, and fallback to ours instead of only using ours, which causes aar incompatibility with some libraries. 

This is done to avoid the following errors:
```
Execution failed for task ':react-native-vector-icons_material-icons:checkDebugAndroidTestAarMetadata'.
> A failure occurred while executing com.android.build.gradle.internal.tasks.CheckAarMetadataWorkAction
   > 8 issues were found when checking AAR metadata:

       1.  Dependency 'androidx.appcompat:appcompat-resources:1.6.1' requires libraries and applications that
           depend on it to compile against version 33 or later of the
           Android APIs.
```