### PR TITLE
refactor: stricter Expo compatibility checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,13 +201,13 @@ animation library
 
 ## Dynamic icon font loading
 
-> At the moment, dynamic loading is supported on native platforms (not on web) only if you use Expo. In the future, it should become available for all React Native projects via React Native core.
+> At the moment, dynamic loading is supported on native platforms (not on web) only if you use Expo ([Expo Go](https://expo.dev/go) or a development client). In the future, it should become available for all React Native projects via React Native core.
 
 Fonts can be available in an app statically (since build time) or loaded dynamically at runtime. The latter can be useful e.g. for apps that use over-the-air updates and want to load new fonts with an update, or when you need to use a font from a remote location.
 
 Dynamic loading in react-native-vector-icons is currently limited to those fonts that are bundled within the provided packages: it doesn't support Pro fonts (such as FontAwesome 5 Pro). However, loading of custom fonts is not difficult to implement: see any of the free font packages for reference.
 
-By default, dynamic loading is enabled if supported by the version of Expo that you're using. It doesn't change the way you work with the package: If rendering an icon requires a font that is not known to the app, it will be loaded automatically and icon will render as expected.
+By default, dynamic loading is enabled if you run Expo SDK >= 52. It doesn't change the way you work with the package: If rendering an icon requires a font that is not known to the app, it will be loaded automatically and icon will render as expected.
 
 `@react-native-vector-icons/common` exports several functions which you can use to control dynamic loading:
 


### PR DESCRIPTION
### why 

This PR increases strictness of checks of expo modules upon the `globalThis.expo`.

Also, it removes deep import of `react-native/Libraries/Image/resolveAssetSource` from react native because it will soon not be allowed: https://github.com/react-native-community/discussions-and-proposals/pull/894

There are no changes in the runtime behavior.

### test plan

Built the common package locally and installed it into a fresh expo go project. Rendering of icons worked.

that being said, I had to do some workarounds to get `pnpm install` to finish successfully:

```
 ERR_PNPM_FETCH_401  GET https://npm.fontawesome.com/@fortawesome/fontawesome-free/-/fontawesome-free-5.15.4.tgz: Unauthorized - 401

No authorization header was set for the request.
```

Maybe I just missed some docs but at the first sight, this seems to be a hurdle for external contributors.