### PR TITLE
refactor: more efficient default icon styles

### DIFF
--- a/packages/common/src/create-icon-set.tsx
+++ b/packages/common/src/create-icon-set.tsx
@@ -76,6 +76,12 @@ export function createIconSet<GM extends Record<string, number>>(
     default: postScriptName,
   });
 
+  const styleOverrides: TextProps['style'] = {
+    fontFamily: fontReference,
+    fontWeight: 'normal',
+    fontStyle: 'normal',
+  };
+
   const resolveGlyph = (name: keyof GM) => {
     const glyph = glyphMap[name] || '?';
 
@@ -124,12 +130,6 @@ export function createIconSet<GM extends Record<string, number>>(
     const styleDefaults = {
       fontSize: size,
       color,
-    };
-
-    const styleOverrides: TextProps['style'] = {
-      fontFamily: fontReference,
-      fontWeight: 'normal',
-      fontStyle: 'normal',
     };
 
     const newProps: TextProps = {


### PR DESCRIPTION
`styleOverrides` was previously declared inside the `Icon` component, meaning it'd be created for every rendered icon (`<Icon />`).

Now it's created when `createIconSet` is called, and all `<Icon />` renders reuse that style object.