### PR TITLE
fix: put fontawesome pro fonts in the right path

### DIFF
--- a/packages/fontawesome-common/bin/fa-upgrade
+++ b/packages/fontawesome-common/bin/fa-upgrade
@@ -6,6 +6,9 @@ TEMP_DIR_PATH=""
 FONTAWESOME_PRO_DIR_NAME=""
 VERSION=$1
 DEST_DIR_PATH=${2:-"rnvi-fonts"}
+if [ "$VERSION" = "5" ] || [ "$VERSION" = "6" ]; then
+  DEST_DIR_PATH="${DEST_DIR_PATH}/fontawesome${VERSION}-pro"
+fi
 FONT_NAME="Font Awesome Pro ${VERSION}"
 
 setup_npm_config() {

--- a/packages/fontawesome5-pro/README.md
+++ b/packages/fontawesome5-pro/README.md
@@ -7,13 +7,13 @@ account and then access the `Services` tab.
 
 Run `npx fa-upgrade5` and enter the token
 when asked to in order to upgrade to the Pro version. It will install the fonts
-in your repo in the `rnvi-fonts` directory but the folder can be customized by
+in your repo in the `rnvi-fonts/fontawesome5-pro` directory but the folder can be customized by
 setting it when executing the command: `npx fa-upgrade5 [destination]`.
 
 ### Manually
 
 If the shell script does not work you can install the Pro version manually.
-All you really need to do is adding the Pro fonts to the `rnvi-fonts` directory.
+All you really need to do is adding the Pro fonts to the `rnvi-fonts/fontawesome5-pro` directory.
 
 ## Usage
 

--- a/packages/fontawesome6-pro/README.md
+++ b/packages/fontawesome6-pro/README.md
@@ -7,13 +7,13 @@ account and then access the `Services` tab.
 
 Run `npx fa-upgrade6` and enter the token
 when asked to in order to upgrade to the Pro version. It will install the fonts
-in your repo in the `rnvi-fonts` directory but the folder can be customized by
+in your repo in the `rnvi-fonts/fontawesome6-pro` directory but the folder can be customized by
 setting it when executing the command: `npx fa-upgrade6 [destination]`.
 
 ### Manually
 
 If the shell script does not work you can install the Pro version manually.
-All you really need to do is adding the Pro fonts to the `rnvi-fonts` directory.
+All you really need to do is adding the Pro fonts to the `rnvi-fonts/fontawesome6-pro` directory.
 
 ## Usage
 


### PR DESCRIPTION
I installed 12.0.1 version of the fontweasome6-pro pacakge. On running the `npx fa-upgrade6` command, it downloads the fonts into rnvi-fonts dir.

These fonts were not getting picked during the build process and on investigation I see that both the [gradle script](https://github.com/oblador/react-native-vector-icons/blob/master/packages/fontawesome6-pro/android/build.gradle#L67) and [podspec script](https://github.com/oblador/react-native-vector-icons/blob/master/packages/fontawesome6-pro/react-native-vector-icons-fontawesome6-pro.podspec#L50) expects the fonts to be in `rnvi-fonts/fontawesome6-pro` directory

So I modified the fa-upgrade script to append this to the destination directory path.