### PR TITLE
Update FontAwesome import to use FontAwesome6 instead of FontAwesome5

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ By combining some of these you can create for example :
 Some fonts today use multiple styles, FontAwesome 5 for example, which is supported by this library. The usage is pretty much the same as the standard `Icon` component:
 
 ```jsx
-import Icon from '@react-native-vector-icons/fontawesome5';
+import Icon from '@react-native-vector-icons/fontawesome6';
 
 const myIcon1 = <Icon name="comments" size={30} color="#900" />; // Defaults to solid
 const myIcon2 = <Icon name="comments" size={30} color="#900" iconType="solid" />;


### PR DESCRIPTION
fix: change FontAwesome5 import to FontAwesome6

The code was importing FontAwesome5, which does not work with the current setup even after installing @react-native-vector-icons. Updated the import to use FontAwesome6, which resolves the issue and ensures icons render correctly.