### PR TITLE
fix(web): throw a meaningful error in getImageForFont

### DIFF
--- a/packages/get-image/src/NativeVectorIcons.web.ts
+++ b/packages/get-image/src/NativeVectorIcons.web.ts
@@ -1,1 +1,12 @@
-export default {};
+import type { Spec } from './NativeVectorIcons';
+
+const webImpl: Spec = {
+  async getImageForFont() {
+    throw new Error('getImageForFont is not available for web');
+  },
+  getImageForFontSync() {
+    throw new Error('getImageForFontSync is not available for web');
+  },
+};
+
+export default webImpl;

--- a/packages/get-image/src/ensure-native-module-available.ts
+++ b/packages/get-image/src/ensure-native-module-available.ts
@@ -1,6 +1,6 @@
 import NativeIconAPI from './NativeVectorIcons';
 
-export default function ensureNativeModuleAvailable() {
+export function ensureNativeModuleAvailable() {
   if (!NativeIconAPI) {
     throw new Error(
       'The native RNVectorIcons API is not available, did you properly integrate the module? Please verify your autolinking setup and recompile.',

--- a/packages/get-image/src/index.ts
+++ b/packages/get-image/src/index.ts
@@ -1,6 +1,6 @@
 import { Platform } from 'react-native';
 
-export { default as ensureNativeModuleAvailable } from './ensure-native-module-available';
+export { ensureNativeModuleAvailable } from './ensure-native-module-available';
 
 const LINKING_ERROR = `
   The package '@react-native-vector-icons/get-image' doesn't seem to be linked. Make sure:


### PR DESCRIPTION
With the previous impl, web users would simply get `VectorIcons.getImageForFont is not a function` which looks like a bug in this lib, or the user's setup. This explains the situation a bit better.