### PR TITLE
Move direct dep on rnc/cli-tools to dev/peer deps

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -77,11 +77,11 @@
     "registry": "https://registry.npmjs.org/"
   },
   "dependencies": {
-    "@react-native-community/cli-tools": "^17.0.0",
     "picocolors": "^1.1.1",
     "plist": "^3.1.0"
   },
   "devDependencies": {
+    "@react-native-community/cli-tools": "^17.0.0",
     "@types/plist": "^3.0.5",
     "@types/react": "^19.0.12",
     "del-cli": "^6.0.0",
@@ -90,6 +90,7 @@
     "typescript": "^5.7.2"
   },
   "peerDependencies": {
+    "@react-native-community/cli-tools": ">=9.0.0",
     "@react-native-vector-icons/get-image": "workspace:^",
     "react": "*",
     "react-native": "*"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -142,9 +142,6 @@ importers:
 
   packages/common:
     dependencies:
-      '@react-native-community/cli-tools':
-        specifier: ^17.0.0
-        version: 17.0.0
       '@react-native-vector-icons/get-image':
         specifier: workspace:^
         version: link:../get-image
@@ -161,6 +158,9 @@ importers:
         specifier: '*'
         version: 0.79.0(@babel/core@7.26.9)(@react-native-community/cli@18.0.0(typescript@5.8.3))(@types/react@19.1.8)(react@19.0.0)
     devDependencies:
+      '@react-native-community/cli-tools':
+        specifier: ^17.0.0
+        version: 17.0.0
       '@types/plist':
         specifier: ^3.0.5
         version: 3.0.5


### PR DESCRIPTION
This decouples `@react-native-vector-icons/common` from a specific version (currently `^17.0.0`) of `@react-native-community/cli-tools`.

The only function currently used is `resolveNodeModuleDir`, which in this form first appeared in cli-tools 9.0.0 (which is why the peer dependency was set to `">=9.0.0"`).

Different version of React Native use different versions of `@react-native-community/cli-tools`. There should be no reason to pull in duplicates.