### PR TITLE
chore: reduce amount of native builds in CI

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         api-level: [35]
-        rn-version: ["0.78", "0.77", "0.76", "0.75", "0.74", "0.73"]
+        rn-version: ["0.80", "0.76"]
         arch: ["new", "old"]
 
     steps:
@@ -148,7 +148,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rn-version: ["0.78", "0.77", "0.76", "0.75", "0.74", "0.73"]
+        rn-version: ["0.80", "0.76"]
         arch: ["new", "old"]
 
     steps:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -2,8 +2,12 @@
 name: Tests
 
 on:
-  - push
-  - pull_request
+  push:
+    branches: [master, main]
+  pull_request:
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
 
 permissions:
   # AWS


### PR DESCRIPTION
The CI runs a large number of native builds, and even runs the same job twice, so it takes very long.

There's very little native code in the packages so running all these adds little value compared to running one or two versions.

---

Not sure what the CI failure is about.