### PR TITLE
feat: add 'use client' directive for RSC

### DIFF
--- a/packages/ant-design/src/index.ts
+++ b/packages/ant-design/src/index.ts
@@ -1,9 +1,9 @@
-// NOTE:This file was generated from packages/generator-react-native-vector-icons/src/app/templates
-// If you're contributing to react-native-vector-icons, make the change there, otherwise it'll be lost
+'use client';
 
 /**
  * This is a generated file. If you modify it manually, your changes will be lost!
- * Instead, modify the template in `generator-react-native-vector-icons`.
+ * This file was generated from packages/generator-react-native-vector-icons/src/app/templates
+ * If you're contributing to react-native-vector-icons, make the change there; otherwise it'll be lost
  *
  * AntDesign icon set component.
  * Usage: <AntDesign name="icon-name" size={20} color="#4F8EF7" />

--- a/packages/entypo/src/index.ts
+++ b/packages/entypo/src/index.ts
@@ -1,9 +1,9 @@
-// NOTE:This file was generated from packages/generator-react-native-vector-icons/src/app/templates
-// If you're contributing to react-native-vector-icons, make the change there, otherwise it'll be lost
+'use client';
 
 /**
  * This is a generated file. If you modify it manually, your changes will be lost!
- * Instead, modify the template in `generator-react-native-vector-icons`.
+ * This file was generated from packages/generator-react-native-vector-icons/src/app/templates
+ * If you're contributing to react-native-vector-icons, make the change there; otherwise it'll be lost
  *
  * Entypo icon set component.
  * Usage: <Entypo name="icon-name" size={20} color="#4F8EF7" />

--- a/packages/evil-icons/src/index.ts
+++ b/packages/evil-icons/src/index.ts
@@ -1,9 +1,9 @@
-// NOTE:This file was generated from packages/generator-react-native-vector-icons/src/app/templates
-// If you're contributing to react-native-vector-icons, make the change there, otherwise it'll be lost
+'use client';
 
 /**
  * This is a generated file. If you modify it manually, your changes will be lost!
- * Instead, modify the template in `generator-react-native-vector-icons`.
+ * This file was generated from packages/generator-react-native-vector-icons/src/app/templates
+ * If you're contributing to react-native-vector-icons, make the change there; otherwise it'll be lost
  *
  * EvilIcons icon set component.
  * Usage: <EvilIcons name="icon-name" size={20} color="#4F8EF7" />

--- a/packages/feather/src/index.ts
+++ b/packages/feather/src/index.ts
@@ -1,9 +1,9 @@
-// NOTE:This file was generated from packages/generator-react-native-vector-icons/src/app/templates
-// If you're contributing to react-native-vector-icons, make the change there, otherwise it'll be lost
+'use client';
 
 /**
  * This is a generated file. If you modify it manually, your changes will be lost!
- * Instead, modify the template in `generator-react-native-vector-icons`.
+ * This file was generated from packages/generator-react-native-vector-icons/src/app/templates
+ * If you're contributing to react-native-vector-icons, make the change there; otherwise it'll be lost
  *
  * Feather icon set component.
  * Usage: <Feather name="icon-name" size={20} color="#4F8EF7" />

--- a/packages/fontawesome/src/index.ts
+++ b/packages/fontawesome/src/index.ts
@@ -1,9 +1,9 @@
-// NOTE:This file was generated from packages/generator-react-native-vector-icons/src/app/templates
-// If you're contributing to react-native-vector-icons, make the change there, otherwise it'll be lost
+'use client';
 
 /**
  * This is a generated file. If you modify it manually, your changes will be lost!
- * Instead, modify the template in `generator-react-native-vector-icons`.
+ * This file was generated from packages/generator-react-native-vector-icons/src/app/templates
+ * If you're contributing to react-native-vector-icons, make the change there; otherwise it'll be lost
  *
  * FontAwesome icon set component.
  * Usage: <FontAwesome name="icon-name" size={20} color="#4F8EF7" />

--- a/packages/fontisto/src/index.ts
+++ b/packages/fontisto/src/index.ts
@@ -1,9 +1,9 @@
-// NOTE:This file was generated from packages/generator-react-native-vector-icons/src/app/templates
-// If you're contributing to react-native-vector-icons, make the change there, otherwise it'll be lost
+'use client';
 
 /**
  * This is a generated file. If you modify it manually, your changes will be lost!
- * Instead, modify the template in `generator-react-native-vector-icons`.
+ * This file was generated from packages/generator-react-native-vector-icons/src/app/templates
+ * If you're contributing to react-native-vector-icons, make the change there; otherwise it'll be lost
  *
  * Fontisto icon set component.
  * Usage: <Fontisto name="icon-name" size={20} color="#4F8EF7" />

--- a/packages/foundation/src/index.ts
+++ b/packages/foundation/src/index.ts
@@ -1,9 +1,9 @@
-// NOTE:This file was generated from packages/generator-react-native-vector-icons/src/app/templates
-// If you're contributing to react-native-vector-icons, make the change there, otherwise it'll be lost
+'use client';
 
 /**
  * This is a generated file. If you modify it manually, your changes will be lost!
- * Instead, modify the template in `generator-react-native-vector-icons`.
+ * This file was generated from packages/generator-react-native-vector-icons/src/app/templates
+ * If you're contributing to react-native-vector-icons, make the change there; otherwise it'll be lost
  *
  * Foundation icon set component.
  * Usage: <Foundation name="icon-name" size={20} color="#4F8EF7" />

--- a/packages/generator-react-native-vector-icons/src/app/templates/src/index.ts
+++ b/packages/generator-react-native-vector-icons/src/app/templates/src/index.ts
@@ -1,4 +1,5 @@
 'use client';
+
 /**
  * This is a generated file. If you modify it manually, your changes will be lost!
  * This file was generated from packages/generator-react-native-vector-icons/src/app/templates

--- a/packages/generator-react-native-vector-icons/src/app/templates/src/index.ts
+++ b/packages/generator-react-native-vector-icons/src/app/templates/src/index.ts
@@ -1,9 +1,8 @@
-// NOTE:This file was generated from packages/generator-react-native-vector-icons/src/app/templates
-// If you're contributing to react-native-vector-icons, make the change there, otherwise it'll be lost
-
+'use client';
 /**
  * This is a generated file. If you modify it manually, your changes will be lost!
- * Instead, modify the template in `generator-react-native-vector-icons`.
+ * This file was generated from packages/generator-react-native-vector-icons/src/app/templates
+ * If you're contributing to react-native-vector-icons, make the change there; otherwise it'll be lost
  *
  * <%= className %> icon set component.
  * Usage: <<%= className %> name="icon-name" size={20} color="#4F8EF7" />

--- a/packages/ionicons/src/index.ts
+++ b/packages/ionicons/src/index.ts
@@ -1,9 +1,9 @@
-// NOTE:This file was generated from packages/generator-react-native-vector-icons/src/app/templates
-// If you're contributing to react-native-vector-icons, make the change there, otherwise it'll be lost
+'use client';
 
 /**
  * This is a generated file. If you modify it manually, your changes will be lost!
- * Instead, modify the template in `generator-react-native-vector-icons`.
+ * This file was generated from packages/generator-react-native-vector-icons/src/app/templates
+ * If you're contributing to react-native-vector-icons, make the change there; otherwise it'll be lost
  *
  * Ionicons icon set component.
  * Usage: <Ionicons name="icon-name" size={20} color="#4F8EF7" />

--- a/packages/lucide/src/index.ts
+++ b/packages/lucide/src/index.ts
@@ -1,9 +1,9 @@
-// NOTE:This file was generated from packages/generator-react-native-vector-icons/src/app/templates
-// If you're contributing to react-native-vector-icons, make the change there, otherwise it'll be lost
+'use client';
 
 /**
  * This is a generated file. If you modify it manually, your changes will be lost!
- * Instead, modify the template in `generator-react-native-vector-icons`.
+ * This file was generated from packages/generator-react-native-vector-icons/src/app/templates
+ * If you're contributing to react-native-vector-icons, make the change there; otherwise it'll be lost
  *
  * Lucide icon set component.
  * Usage: <Lucide name="icon-name" size={20} color="#4F8EF7" />

--- a/packages/material-design-icons/src/index.ts
+++ b/packages/material-design-icons/src/index.ts
@@ -1,9 +1,9 @@
-// NOTE:This file was generated from packages/generator-react-native-vector-icons/src/app/templates
-// If you're contributing to react-native-vector-icons, make the change there, otherwise it'll be lost
+'use client';
 
 /**
  * This is a generated file. If you modify it manually, your changes will be lost!
- * Instead, modify the template in `generator-react-native-vector-icons`.
+ * This file was generated from packages/generator-react-native-vector-icons/src/app/templates
+ * If you're contributing to react-native-vector-icons, make the change there; otherwise it'll be lost
  *
  * MaterialDesignIcons icon set component.
  * Usage: <MaterialDesignIcons name="icon-name" size={20} color="#4F8EF7" />

--- a/packages/material-icons/src/index.ts
+++ b/packages/material-icons/src/index.ts
@@ -1,9 +1,9 @@
-// NOTE:This file was generated from packages/generator-react-native-vector-icons/src/app/templates
-// If you're contributing to react-native-vector-icons, make the change there, otherwise it'll be lost
+'use client';
 
 /**
  * This is a generated file. If you modify it manually, your changes will be lost!
- * Instead, modify the template in `generator-react-native-vector-icons`.
+ * This file was generated from packages/generator-react-native-vector-icons/src/app/templates
+ * If you're contributing to react-native-vector-icons, make the change there; otherwise it'll be lost
  *
  * MaterialIcons icon set component.
  * Usage: <MaterialIcons name="icon-name" size={20} color="#4F8EF7" />

--- a/packages/octicons/src/index.ts
+++ b/packages/octicons/src/index.ts
@@ -1,9 +1,9 @@
-// NOTE:This file was generated from packages/generator-react-native-vector-icons/src/app/templates
-// If you're contributing to react-native-vector-icons, make the change there, otherwise it'll be lost
+'use client';
 
 /**
  * This is a generated file. If you modify it manually, your changes will be lost!
- * Instead, modify the template in `generator-react-native-vector-icons`.
+ * This file was generated from packages/generator-react-native-vector-icons/src/app/templates
+ * If you're contributing to react-native-vector-icons, make the change there; otherwise it'll be lost
  *
  * Octicons icon set component.
  * Usage: <Octicons name="icon-name" size={20} color="#4F8EF7" />

--- a/packages/simple-line-icons/src/index.ts
+++ b/packages/simple-line-icons/src/index.ts
@@ -1,9 +1,9 @@
-// NOTE:This file was generated from packages/generator-react-native-vector-icons/src/app/templates
-// If you're contributing to react-native-vector-icons, make the change there, otherwise it'll be lost
+'use client';
 
 /**
  * This is a generated file. If you modify it manually, your changes will be lost!
- * Instead, modify the template in `generator-react-native-vector-icons`.
+ * This file was generated from packages/generator-react-native-vector-icons/src/app/templates
+ * If you're contributing to react-native-vector-icons, make the change there; otherwise it'll be lost
  *
  * SimpleLineIcons icon set component.
  * Usage: <SimpleLineIcons name="icon-name" size={20} color="#4F8EF7" />

--- a/packages/zocial/src/index.ts
+++ b/packages/zocial/src/index.ts
@@ -1,9 +1,9 @@
-// NOTE:This file was generated from packages/generator-react-native-vector-icons/src/app/templates
-// If you're contributing to react-native-vector-icons, make the change there, otherwise it'll be lost
+'use client';
 
 /**
  * This is a generated file. If you modify it manually, your changes will be lost!
- * Instead, modify the template in `generator-react-native-vector-icons`.
+ * This file was generated from packages/generator-react-native-vector-icons/src/app/templates
+ * If you're contributing to react-native-vector-icons, make the change there; otherwise it'll be lost
  *
  * Zocial icon set component.
  * Usage: <Zocial name="icon-name" size={20} color="#4F8EF7" />


### PR DESCRIPTION
The icon components are client components and should be marked with `'use client'` directive for RSC usage.

I haven't found the right way to apply the change from the template file to the individual packages; there's the standard `CONTRBUTING` file but also `docs/DEVELOPMENT` which seems like they should be merged into one (?) - probably the `CONTRBUTING` file which is a the expected place to find this stuff.

