### PR TITLE
[codemod] add codemod for expo/vector-icons

### DIFF
--- a/packages/codemod/src/11.0/package-json.ts
+++ b/packages/codemod/src/11.0/package-json.ts
@@ -1,21 +1,17 @@
 import fs from 'node:fs';
-
-const getVersion = async (pkg: string) => {
-  const packageJson = await fetch(`https://registry.npmjs.org/${pkg}/latest`).then(
-    (res) => res.json() as unknown as { version: string },
-  );
-  return `^${packageJson.version}`;
-};
+import { getVersion } from '../getVersion';
 
 export default async (pkgs: Set<string>) => {
   const packageJson = JSON.parse(fs.readFileSync('package.json', 'utf8'));
   const { dependencies } = packageJson;
 
-  pkgs.forEach(async (pkg) => {
+  const versionPromises = Array.from(pkgs).map(async (pkg) => {
     if (!dependencies[pkg]) {
       dependencies[pkg] = await getVersion(pkg);
     }
   });
+
+  await Promise.all(versionPromises);
 
   if (pkgs.size > 0 && dependencies['react-native-vector-icons']) {
     dependencies['react-native-vector-icons'] = undefined;

--- a/packages/codemod/src/expo/import-transform.ts
+++ b/packages/codemod/src/expo/import-transform.ts
@@ -1,0 +1,91 @@
+import type { FileInfo, API } from 'jscodeshift';
+import { addNewFontImport } from './newFontImports';
+
+const importsMap: Record<string, string> = {
+  '@expo/vector-icons/AntDesign': '@react-native-vector-icons/ant-design',
+  '@expo/vector-icons/Entypo': '@react-native-vector-icons/entypo',
+  '@expo/vector-icons/EvilIcons': '@react-native-vector-icons/evil-icons',
+  '@expo/vector-icons/Feather': '@react-native-vector-icons/feather',
+  '@expo/vector-icons/FontAwesome5': '@react-native-vector-icons/fontawesome5',
+  '@expo/vector-icons/FontAwesome5Pro': '@react-native-vector-icons/fontawesome5-pro',
+  '@expo/vector-icons/FontAwesome6': '@react-native-vector-icons/fontawesome6',
+  '@expo/vector-icons/FontAwesome6Pro': '@react-native-vector-icons/fontawesome6-pro',
+  '@expo/vector-icons/FontAwesome': '@react-native-vector-icons/fontawesome',
+  '@expo/vector-icons/Fontisto': '@react-native-vector-icons/fontisto',
+  '@expo/vector-icons/Foundation': '@react-native-vector-icons/foundation',
+  '@expo/vector-icons/Ionicons': '@react-native-vector-icons/ionicons',
+  '@expo/vector-icons/MaterialCommunityIcons': '@react-native-vector-icons/material-design-icons',
+  '@expo/vector-icons/MaterialIcons': '@react-native-vector-icons/material-icons',
+  '@expo/vector-icons/Octicons': '@react-native-vector-icons/octicons',
+  '@expo/vector-icons/SimpleLineIcons': '@react-native-vector-icons/SimpleLineIcons',
+  '@expo/vector-icons/Zocial': '@react-native-vector-icons/zocial',
+};
+
+// prefer transforms to default imports as they are easier to get right than named imports
+export default function transform(fileInfo: FileInfo, api: API) {
+  const j = api.jscodeshift;
+  const root = j(fileInfo.source);
+
+  const newFontImports = new Set<string>();
+
+  // Transform import statements from @expo/vector-icons
+  root.find(j.ImportDeclaration).forEach((path) => {
+    const { source } = path.value;
+
+    // Handle named imports: import { Ionicons, MaterialIcons } from '@expo/vector-icons'
+    if (source.type === 'StringLiteral' && source.value === '@expo/vector-icons') {
+      const { specifiers } = path.value;
+
+      if (specifiers) {
+        const newImports = specifiers
+          .map((spec) => {
+            if (spec.type === 'ImportSpecifier') {
+              const fontName = spec.imported.name;
+
+              // Find the correct mapping for this font
+              const oldName = `@expo/vector-icons/${fontName}`;
+              const newFontPath = importsMap[oldName];
+              if (!newFontPath) {
+                throw new Error(`No mapping found for ${oldName}. Migrate this import manually.`);
+              }
+
+              newFontImports.add(newFontPath);
+
+              return j.importDeclaration([j.importDefaultSpecifier(j.identifier(fontName))], j.literal(newFontPath));
+            }
+            return null;
+          })
+          .filter(Boolean);
+
+        // Replace the original import with new imports
+        if (newImports.length > 0) {
+          j(path).replaceWith(newImports);
+        }
+      }
+    }
+
+    // Handle default imports: import Ionicons from '@expo/vector-icons/Ionicons'
+    // or 'import Ionicons from '@expo/vector-icons/build/Ionicons'
+    if (
+      source.type === 'StringLiteral' &&
+      typeof source.value === 'string' &&
+      source.value.startsWith('@expo/vector-icons/')
+    ) {
+      const importPath = source.value.replace('/build/', '/');
+      const newFontPath = importsMap[importPath];
+      if (!newFontPath) {
+        throw new Error(`No mapping found for ${source.value}. Migrate this import manually.`);
+      }
+      newFontImports.add(newFontPath);
+
+      // Replace with new import
+      source.value = newFontPath;
+    }
+  });
+
+  if (newFontImports.size > 0) {
+    addNewFontImport(Array.from(newFontImports));
+  }
+
+  return newFontImports.size > 0 ? root.toSource() : undefined;
+}

--- a/packages/codemod/src/expo/index.ts
+++ b/packages/codemod/src/expo/index.ts
@@ -1,0 +1,17 @@
+import { run as jscodeshift } from 'jscodeshift/src/Runner';
+import { updatePackageJson } from './package-json';
+
+export async function runExpoMigration(dir: string) {
+  const transformPath = require.resolve('./import-transform');
+
+  process.chdir(dir);
+  console.log(`Running Expo codemod in directory: ${dir}`);
+
+  await jscodeshift(transformPath, ['.'], {
+    verbose: process.env.VERBOSE === 'true' || process.env.VERBOSE === '1',
+    extensions: 'js,jsx,ts,tsx',
+    parser: 'tsx',
+    ignorePattern: '**/node_modules/**',
+  });
+  await updatePackageJson(dir);
+}

--- a/packages/codemod/src/expo/newFontImports.ts
+++ b/packages/codemod/src/expo/newFontImports.ts
@@ -1,0 +1,19 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const tmpFile = path.join(os.tmpdir(), 'rnvi-codemod-new-imports.txt');
+
+export function addNewFontImport(fontNames: string[]) {
+  // this should be atomic and safe to call from multiple processes
+  fs.appendFileSync(tmpFile, fontNames.join(os.EOL) + os.EOL);
+}
+
+export function getNewFontImports(): string[] {
+  if (!fs.existsSync(tmpFile)) {
+    return [];
+  }
+  const content = fs.readFileSync(tmpFile, 'utf8');
+  fs.unlinkSync(tmpFile);
+  return Array.from(new Set(content.split(os.EOL).filter(Boolean)));
+}

--- a/packages/codemod/src/expo/package-json.ts
+++ b/packages/codemod/src/expo/package-json.ts
@@ -1,0 +1,40 @@
+import os from 'node:os';
+import fs from 'node:fs';
+import path from 'node:path';
+import { getNewFontImports } from './newFontImports';
+import { getVersion } from '../getVersion';
+
+export async function updatePackageJson(dir: string) {
+  const packageJsonPath = path.join(dir, 'package.json');
+
+  if (!fs.existsSync(packageJsonPath)) {
+    console.error('package.json not found');
+    return;
+  }
+
+  const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+  if (!packageJson) {
+    console.error('package.json is not valid');
+    return;
+  }
+
+  if (packageJson.dependencies?.['@expo/vector-icons']) {
+    delete packageJson.dependencies['@expo/vector-icons'];
+  }
+
+  if (!packageJson.dependencies) {
+    packageJson.dependencies = {};
+  }
+
+  const newFontImports = getNewFontImports();
+  const latestVersions = await Promise.all(newFontImports.map((font) => getVersion(font)));
+  newFontImports.forEach((font, index) => {
+    packageJson.dependencies[font] = latestVersions[index];
+  });
+
+  fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2) + os.EOL);
+
+  console.log(
+    `Removed @expo/vector-icons and added ${newFontImports.length} font packages: ${newFontImports.join(', ')}`,
+  );
+}

--- a/packages/codemod/src/getVersion.ts
+++ b/packages/codemod/src/getVersion.ts
@@ -1,0 +1,6 @@
+export const getVersion = async (pkg: string) => {
+  const packageJson = await fetch(`https://registry.npmjs.org/${pkg}/latest`).then(
+    (res) => res.json() as unknown as { version: string },
+  );
+  return `^${packageJson.version}`;
+};

--- a/packages/codemod/src/index.ts
+++ b/packages/codemod/src/index.ts
@@ -3,44 +3,72 @@
 /* eslint-disable no-console */
 
 import path from 'node:path';
-
 import semver from 'semver';
+import { runExpoMigration } from './expo';
+import { readPackageDeps } from './readPackageDeps';
 
-const dir = process.argv[2];
-if (!dir) {
-  console.error('Please specify a directory to transform');
-  process.exit(1);
-}
-
-// eslint-disable-next-line import/no-dynamic-require,@typescript-eslint/no-require-imports
-const projectPkgJson = require(path.join(dir, 'package.json'));
-
-const { dependencies } = projectPkgJson;
-
-let version: string;
-
-if (dependencies['react-native-vector-icons']) {
-  version = '11.x';
-  await import('./11.0');
-} else {
-  const currentVersion = dependencies['@react-native-vector-icons/common'];
-
-  if (semver.satisfies(currentVersion, '12.x')) {
-    version = '12.x';
-    await import('./12.0');
-  } else {
-    console.error('Unsupported version of react-native-vector-icons');
+async function main() {
+  const dir = process.argv[2];
+  if (!dir) {
+    console.error('Specify a directory in which to run the codemod');
     process.exit(1);
+  }
+
+  const { dependencies, error } = readPackageDeps(dir);
+
+  if (error) {
+    console.error(`Unable to read package.json in ${dir}: ${error.message}`);
+    process.exit(1);
+  }
+
+  console.log('Running codemod in', dir);
+
+  let version: string | undefined;
+
+  const expoVectorIcons = dependencies['@expo/vector-icons'];
+
+  if (expoVectorIcons) {
+    await runExpoMigration(dir);
+    console.log('Transform complete! Reinstall npm dependencies to use the new versions.');
+  } else {
+    if (dependencies['react-native-vector-icons']) {
+      version = '11.x';
+      await import('./11.0');
+    } else {
+      const currentVersion = dependencies['@react-native-vector-icons/common'];
+
+      if (currentVersion) {
+        if (semver.satisfies(currentVersion, '12.x')) {
+          version = '12.x';
+          await import('./12.0');
+        } else {
+          console.error('Unsupported version of react-native-vector-icons');
+          process.exit(1);
+        }
+      }
+    }
+
+    if (!version) {
+      console.error(
+        `Have not found anything to migrate. Do you have "react-native-vector-icons" or "@expo/vector-icons" at ${path.join(dir, 'package.json')}?`,
+      );
+      process.exit(1);
+    }
+
+    console.log(`
+  Transform complete!
+  
+  Upgraded to version ${version}
+  
+  NOTE: You may need to run again to upgrade to the next version.
+  NOTE: You may need to run 'npm install' to install new dependencies.
+  
+  Check https://github.com/react-native-vector-icons/react-native-vector-icons/blob/master/MIGRATION.md for any manual steps
+  `);
   }
 }
 
-console.log(`
-Transform complete!
-
-Upgraded to version ${version}
-
-NOTE: You may need to run again to upgrade to the next version.
-NOTE: You may need to run 'npm install' to install new dependencies.
-
-Please check https://github.com/react-native-vector-icons/react-native-vector-icons/blob/master/MIGRATION.md for any manual steps
-`);
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/packages/codemod/src/readPackageDeps.ts
+++ b/packages/codemod/src/readPackageDeps.ts
@@ -1,0 +1,28 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+type Result =
+  | {
+      dependencies: Record<string, string>;
+      error: null;
+    }
+  | {
+      dependencies: null;
+      error: Error;
+    };
+
+export const readPackageDeps = (dir: string): Result => {
+  try {
+    const packageJsonPath = path.join(dir, 'package.json');
+    const { dependencies: pkgDependencies } = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8')) as {
+      dependencies: Record<string, string>;
+    };
+
+    return {
+      dependencies: pkgDependencies || {},
+      error: null,
+    };
+  } catch (err) {
+    return { dependencies: null, error: err as Error };
+  }
+};


### PR DESCRIPTION
this adds a codemod that migrates from `@expo/vector-icons` to the new per-icon-family packages. It transforms the imports, and updates package.json

supported syntax:

named imports:
```
import { Ionicons, MaterialIcons } from '@expo/vector-icons'
```

default imports:

```
import Ionicons from '@expo/vector-icons/Ionicons'
```

