### PR TITLE
[chore] reduce redundant CI runs

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -86,4 +86,4 @@ jobs:
         run: pnpm install
 
       - name: Check for unused things
-        run: pnpm run knip
+        run: pnpm run lint:knip

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -8,13 +8,15 @@ on:
     paths:
       - ".github/workflows/tests.yaml"
       - "packages/**"
+      - "!packages/directory/**"
+      - "!packages/codemod/**"
       - "scripts/**"
-      - "android/**"
-      - "ios/**"
   pull_request:
     paths:
       - ".github/workflows/tests.yaml"
       - "packages/**"
+      - "!packages/directory/**"
+      - "!packages/codemod/**"
       - "scripts/**"
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
The CI still runs the same workflows twice, because they are triggered both by `push` and also `pull_request` event.

Reduce the CI runs to only run once, and only for changes in relevant folders (not needed to run native CI builds when updating docs)