### PR TITLE
[codemod] add git status check, use npx expo install to add deps

### DIFF
--- a/packages/codemod/src/checkGitStatus.ts
+++ b/packages/codemod/src/checkGitStatus.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import { execSync } from 'child_process';
 
 export function checkGitStatus(dir: string): void {

--- a/packages/codemod/src/checkGitStatus.ts
+++ b/packages/codemod/src/checkGitStatus.ts
@@ -1,0 +1,26 @@
+import { execSync } from 'child_process';
+
+export function checkGitStatus(dir: string): void {
+  try {
+    // Check if the directory is a git repository
+    execSync('git rev-parse --git-dir', { cwd: dir, stdio: 'pipe' });
+
+    // Check if there are any uncommitted changes
+    const status = execSync('git status --porcelain', {
+      cwd: dir,
+      encoding: 'utf8',
+    });
+
+    if (status.trim()) {
+      console.error('❌ Git working directory not clean. Commit or stash your changes before running the codemod.');
+      console.error('Uncommitted changes:');
+      console.error(status);
+      process.exit(1);
+    }
+
+    console.log('✅ Git repository is clean');
+  } catch {
+    // If git rev-parse fails, the directory is not a git repository
+    console.log('⚠️  Directory is not a git repository. Proceeding without git status check.');
+  }
+}

--- a/packages/codemod/src/expo/import-transform.ts
+++ b/packages/codemod/src/expo/import-transform.ts
@@ -20,6 +20,9 @@ const importsMap: Record<string, string> = {
   '@expo/vector-icons/Octicons': '@react-native-vector-icons/octicons',
   '@expo/vector-icons/SimpleLineIcons': '@react-native-vector-icons/SimpleLineIcons',
   '@expo/vector-icons/Zocial': '@react-native-vector-icons/zocial',
+  // non-icon-family imports
+  '@expo/vector-icons/createIconSetFromIcoMoon': '@react-native-vector-icons/icomoon',
+  '@expo/vector-icons/createIconSetFromFontello': '@react-native-vector-icons/fontello',
 };
 
 // prefer transforms to default imports as they are easier to get right than named imports

--- a/packages/codemod/src/expo/package-json.ts
+++ b/packages/codemod/src/expo/package-json.ts
@@ -1,10 +1,10 @@
 /* eslint-disable no-console */
 
+import { execSync } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
-import { getVersion } from '../getVersion';
 import { getNewFontImports } from './newFontImports';
 
 export async function updatePackageJson(dir: string) {
@@ -30,12 +30,13 @@ export async function updatePackageJson(dir: string) {
   }
 
   const newFontImports = getNewFontImports();
-  const latestVersions = await Promise.all(newFontImports.map((font) => getVersion(font)));
-  newFontImports.forEach((font, index) => {
-    packageJson.dependencies[font] = latestVersions[index];
-  });
 
   fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2) + os.EOL);
+
+  execSync(`npx expo install ${newFontImports.join(' ')}`, {
+    cwd: dir,
+    stdio: 'inherit',
+  });
 
   console.log(
     `Removed @expo/vector-icons and added ${newFontImports.length} font packages: ${newFontImports.join(', ')}`,

--- a/packages/codemod/src/expo/package-json.ts
+++ b/packages/codemod/src/expo/package-json.ts
@@ -39,6 +39,7 @@ export async function updatePackageJson(dir: string) {
   });
 
   console.log(
-    `Removed @expo/vector-icons and added ${newFontImports.length} font packages: ${newFontImports.join(', ')}`,
+    `@expo/vector-icons was removed from package.json. As a replacement, the following ${newFontImports.length} packages were added: ${newFontImports.join(', ')}.`,
   );
+  console.log('If you need to, you can add @expo/vector-icons back by running `npx expo install @expo/vector-icons`');
 }

--- a/packages/codemod/src/index.ts
+++ b/packages/codemod/src/index.ts
@@ -6,6 +6,7 @@ import path from 'node:path';
 
 import semver from 'semver';
 
+import { checkGitStatus } from './checkGitStatus';
 import { runExpoMigration } from './expo';
 import { readPackageDeps } from './readPackageDeps';
 
@@ -15,6 +16,8 @@ async function main() {
     console.error('Specify a directory in which to run the codemod');
     process.exit(1);
   }
+
+  checkGitStatus(dir);
 
   const { dependencies, error } = readPackageDeps(dir);
 
@@ -31,7 +34,6 @@ async function main() {
 
   if (expoVectorIcons) {
     await runExpoMigration(dir);
-    console.log('Transform complete! Reinstall npm dependencies to use the new versions.');
   } else {
     if (dependencies['react-native-vector-icons']) {
       version = '11.x';


### PR DESCRIPTION
- check git status before running the codemod
- install vector icon packages using `npx expo install` in the expo codemod
