### PR TITLE
chore: update templates, close issues by label

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -8,7 +8,7 @@ body:
     attributes:
       value: |
         Thanks for taking the time to fill out this bug report!
-        Before filing a bug report please:
+        Before filing a bug report:
         - Review the documentation: https://github.com/react-native-vector-icons/react-native-vector-icons
         - Search for existing issues (including closed issues): https://github.com/oblador/react-native-vector-icons/issues?q=is%3Aissue+
 
@@ -33,6 +33,17 @@ body:
     validations:
       required: true
 
+  - type: input
+    attributes:
+      label: Minimal reproducible example
+      description: |
+        A link to a GitHub repository containing a minimal reproducible example. This repository should include as little code as possible and not include extraneous dependencies.
+
+        Either provide a link to the repo that reproduces the bug or provide your version of the `App.tsx` file that reproduces the issue and that we can copy-paste and see the issue.
+
+        If a reproducible example is not provided, your issue is likely to be closed.
+        [Learn more about creating a minimal reproducible example](https://stackoverflow.com/help/mcve).
+
   - type: textarea
     id: what-happened
     attributes:
@@ -47,15 +58,8 @@ body:
     id: logs
     attributes:
       label: Relevant log output
-      description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
+      description: Copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
       render: shell
-
-  - type: textarea
-    id: demo
-    attributes:
-      label: Minimal reproducible example
-      description: |
-        Let us know how to reproduce the issue. Include a code sample, share a project, or share an app that reproduces the issue using https://snack.expo.io/. Please follow the guidelines for providing a MCVE: https://stackoverflow.com/help/mcve
 
   - type: textarea
     attributes:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Community Support
-    url: https://github.com/react-native-vector-icons/discussions
+    url: https://github.com/oblador/react-native-vector-icons/discussions
     about: Please ask and answer questions here.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -8,7 +8,7 @@ body:
     attributes:
       value: |
         Thanks for taking the time to suggest a new feature!
-        Before requesting please:
+        Before requesting:
         - Search for existing issues (including closed issues): https://github.com/oblador/react-native-vector-icons/issues?q=is%3Aissue+
 
   - type: textarea
@@ -35,7 +35,7 @@ body:
         A clear and concise description of any alternative solutions or features you've considered.
 
   - type: textarea
-    id: contect
+    id: context
     attributes:
       label: Additional context
       description: |

--- a/.github/workflows/issue-handling.yml
+++ b/.github/workflows/issue-handling.yml
@@ -1,0 +1,22 @@
+name: 'Support requests'
+
+on:
+  issues:
+    types: [labeled, unlabeled, reopened]
+
+jobs:
+  support:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dessant/support-requests@v4
+        with:
+          github-token: ${{ github.token }}
+          support-label: 'missing-repro'
+          issue-comment: >
+            :wave: @{issue-author}, sorry you're having an issue. As the issue template explains, it's required that you provide a runnable example that reproduces your issue (see the [issue template](../blob/main/.github/ISSUE_TEMPLATE/bug_report.yaml)).
+
+            The reason is that a bug report is not actionable without a reproducer. Try to minimize the superfluous code and focus only on reproducing the bug.
+
+            Please create a new issue with this and one of the maintainers will do their best to review it!
+          close-issue: true
+          lock-issue: true


### PR DESCRIPTION
- updated templates. Most notably the bug report template to make it more clear that repros are _required_. Removed the word "please" to make it clear that adding the information is not optional and that we're confident about what we ask, while also being polite about it.
- added automation for `missing-repro` label which will close issues with such label with a friendly message. 

_Maintainers don't have time to fiddle around with issues where it's unclear how to reproduce them; this ensures maintainers' time is well-spent. It's better for issue reporters too because having a repro helps immensely with providing a fix._