### PR TITLE
feat: export font files and glyphmaps

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -185,9 +185,9 @@ When you're sending a pull request:
 
 ### Font generation
 
-All the fonts are automatiaclly generated using a `yeoman` generator. This is driven by a `.yo-rc.json` file in the root of each font.
+All the font packages are automatically generated using a `yeoman` generator. This is driven by a `.yo-rc.json` file in the root of each font.
 
-To make changes to common font files you shuold edit the files in `packages/generator-react-native-vector-icons/src/app/templates/` and then at the root you shuld run:
+To make changes to common font files, edit the files in `packages/generator-react-native-vector-icons/src/app/templates/` and then at the root run:
 
 ```sh
 # Generate all fonts
@@ -199,4 +199,4 @@ pnpm generate ant-design
 
 ### Font versioning
 
-Font package versions are now independent of upstream font versions and we track the mapping in the README.md of each font
+Font package versions are now independent of upstream font versions, and we track the mapping in the README.md of each font

--- a/packages/ant-design/package.json
+++ b/packages/ant-design/package.json
@@ -16,7 +16,9 @@
         "types": "./lib/typescript/commonjs/src/index.d.ts",
         "default": "./lib/commonjs/index.js"
       }
-    }
+    },
+    "./glyphmaps/*.json": "./glyphmaps/*.json",
+    "./fonts/*.ttf": "./fonts/*.ttf"
   },
   "files": [
     "src",

--- a/packages/entypo/package.json
+++ b/packages/entypo/package.json
@@ -16,7 +16,9 @@
         "types": "./lib/typescript/commonjs/src/index.d.ts",
         "default": "./lib/commonjs/index.js"
       }
-    }
+    },
+    "./glyphmaps/*.json": "./glyphmaps/*.json",
+    "./fonts/*.ttf": "./fonts/*.ttf"
   },
   "files": [
     "src",

--- a/packages/evil-icons/package.json
+++ b/packages/evil-icons/package.json
@@ -16,7 +16,9 @@
         "types": "./lib/typescript/commonjs/src/index.d.ts",
         "default": "./lib/commonjs/index.js"
       }
-    }
+    },
+    "./glyphmaps/*.json": "./glyphmaps/*.json",
+    "./fonts/*.ttf": "./fonts/*.ttf"
   },
   "files": [
     "src",

--- a/packages/feather/package.json
+++ b/packages/feather/package.json
@@ -16,7 +16,9 @@
         "types": "./lib/typescript/commonjs/src/index.d.ts",
         "default": "./lib/commonjs/index.js"
       }
-    }
+    },
+    "./glyphmaps/*.json": "./glyphmaps/*.json",
+    "./fonts/*.ttf": "./fonts/*.ttf"
   },
   "files": [
     "src",

--- a/packages/fontawesome/package.json
+++ b/packages/fontawesome/package.json
@@ -16,7 +16,9 @@
         "types": "./lib/typescript/commonjs/src/index.d.ts",
         "default": "./lib/commonjs/index.js"
       }
-    }
+    },
+    "./glyphmaps/*.json": "./glyphmaps/*.json",
+    "./fonts/*.ttf": "./fonts/*.ttf"
   },
   "files": [
     "src",

--- a/packages/fontawesome5-pro/package.json
+++ b/packages/fontawesome5-pro/package.json
@@ -16,7 +16,9 @@
         "types": "./lib/typescript/commonjs/src/index.d.ts",
         "default": "./lib/commonjs/index.js"
       }
-    }
+    },
+    "./glyphmaps/*.json": "./glyphmaps/*.json",
+    "./fonts/*.ttf": "./fonts/*.ttf"
   },
   "files": [
     "src",

--- a/packages/fontawesome5/package.json
+++ b/packages/fontawesome5/package.json
@@ -16,7 +16,9 @@
         "types": "./lib/typescript/commonjs/src/index.d.ts",
         "default": "./lib/commonjs/index.js"
       }
-    }
+    },
+    "./glyphmaps/*.json": "./glyphmaps/*.json",
+    "./fonts/*.ttf": "./fonts/*.ttf"
   },
   "files": [
     "src",

--- a/packages/fontawesome6-pro/package.json
+++ b/packages/fontawesome6-pro/package.json
@@ -16,7 +16,9 @@
         "types": "./lib/typescript/commonjs/src/index.d.ts",
         "default": "./lib/commonjs/index.js"
       }
-    }
+    },
+    "./glyphmaps/*.json": "./glyphmaps/*.json",
+    "./fonts/*.ttf": "./fonts/*.ttf"
   },
   "files": [
     "src",

--- a/packages/fontawesome6/package.json
+++ b/packages/fontawesome6/package.json
@@ -16,7 +16,9 @@
         "types": "./lib/typescript/commonjs/src/index.d.ts",
         "default": "./lib/commonjs/index.js"
       }
-    }
+    },
+    "./glyphmaps/*.json": "./glyphmaps/*.json",
+    "./fonts/*.ttf": "./fonts/*.ttf"
   },
   "files": [
     "src",

--- a/packages/fontello/package.json
+++ b/packages/fontello/package.json
@@ -16,7 +16,9 @@
         "types": "./lib/typescript/commonjs/src/index.d.ts",
         "default": "./lib/commonjs/index.js"
       }
-    }
+    },
+    "./glyphmaps/*.json": "./glyphmaps/*.json",
+    "./fonts/*.ttf": "./fonts/*.ttf"
   },
   "files": [
     "src",

--- a/packages/fontisto/package.json
+++ b/packages/fontisto/package.json
@@ -16,7 +16,9 @@
         "types": "./lib/typescript/commonjs/src/index.d.ts",
         "default": "./lib/commonjs/index.js"
       }
-    }
+    },
+    "./glyphmaps/*.json": "./glyphmaps/*.json",
+    "./fonts/*.ttf": "./fonts/*.ttf"
   },
   "files": [
     "src",

--- a/packages/foundation/package.json
+++ b/packages/foundation/package.json
@@ -16,7 +16,9 @@
         "types": "./lib/typescript/commonjs/src/index.d.ts",
         "default": "./lib/commonjs/index.js"
       }
-    }
+    },
+    "./glyphmaps/*.json": "./glyphmaps/*.json",
+    "./fonts/*.ttf": "./fonts/*.ttf"
   },
   "files": [
     "src",

--- a/packages/generator-react-native-vector-icons/src/app/templates/package.json
+++ b/packages/generator-react-native-vector-icons/src/app/templates/package.json
@@ -16,7 +16,9 @@
         "types": "./lib/typescript/commonjs/src/index.d.ts",
         "default": "./lib/commonjs/index.js"
       }
-    }
+    },
+    "./glyphmaps/*.json": "./glyphmaps/*.json",
+    "./fonts/*.ttf": "./fonts/*.ttf"
   },
   "files": [
     "src",

--- a/packages/icomoon/package.json
+++ b/packages/icomoon/package.json
@@ -16,7 +16,9 @@
         "types": "./lib/typescript/commonjs/src/index.d.ts",
         "default": "./lib/commonjs/index.js"
       }
-    }
+    },
+    "./glyphmaps/*.json": "./glyphmaps/*.json",
+    "./fonts/*.ttf": "./fonts/*.ttf"
   },
   "files": [
     "src",

--- a/packages/icon-explorer/src/IconList.tsx
+++ b/packages/icon-explorer/src/IconList.tsx
@@ -66,11 +66,9 @@ const styles = StyleSheet.create({
 
 const getFilteredGlyphNames = (iconStyle: string | undefined, iconSet: IconSet, query: string) => {
   const icons = iconStyle
-    ? // @ts-expect-error because we don't export the glyphmap
-      (iconSet.meta?.[iconStyle as keyof typeof iconSet.meta] || []).map((name) => [name])
+    ? (iconSet.meta?.[iconStyle as keyof typeof iconSet.meta] || []).map((name) => [name])
     : iconSet.glyphNames;
 
-  // @ts-expect-error because we don't export the glyphmap
   return icons.filter((glyphNames) => glyphNames.find((glyphName) => glyphName.indexOf(query) !== -1));
 };
 

--- a/packages/icon-explorer/src/icon-sets.tsx
+++ b/packages/icon-explorer/src/icon-sets.tsx
@@ -1,66 +1,44 @@
 import { AntDesign } from '@react-native-vector-icons/ant-design';
-// @ts-expect-error: We don't really want to export this
 import AntDesignGlyphs from '@react-native-vector-icons/ant-design/glyphmaps/AntDesign.json';
 import { Entypo } from '@react-native-vector-icons/entypo';
-// @ts-expect-error: We don't really want to export this
 import EntypoGlyphs from '@react-native-vector-icons/entypo/glyphmaps/Entypo.json';
 import { EvilIcons } from '@react-native-vector-icons/evil-icons';
-// @ts-expect-error: We don't really want to export this
 import EvilIconsGlyphs from '@react-native-vector-icons/evil-icons/glyphmaps/EvilIcons.json';
 import { Feather } from '@react-native-vector-icons/feather';
-// @ts-expect-error: We don't really want to export this
 import FeatherGlyphs from '@react-native-vector-icons/feather/glyphmaps/Feather.json';
 import { FontAwesome } from '@react-native-vector-icons/fontawesome';
-// @ts-expect-error: We don't really want to export this
 import FontAwesomeGlyphs from '@react-native-vector-icons/fontawesome/glyphmaps/FontAwesome.json';
 import { FontAwesome5 } from '@react-native-vector-icons/fontawesome5';
-// @ts-expect-error: We don't really want to export this
 import FontAwesome5Glyphs from '@react-native-vector-icons/fontawesome5/glyphmaps/FontAwesome5.json';
-// @ts-expect-error: We don't really want to export this
 import FontAwesome5Meta from '@react-native-vector-icons/fontawesome5/glyphmaps/FontAwesome5_meta.json';
 import { FontAwesome5Pro } from '@react-native-vector-icons/fontawesome5-pro';
-// @ts-expect-error: We don't really want to export this
 import FontAwesome5ProGlyphs from '@react-native-vector-icons/fontawesome5-pro/glyphmaps/FontAwesome5Pro.json';
-// @ts-expect-error: We don't really want to export this
 import FontAwesome5ProMeta from '@react-native-vector-icons/fontawesome5-pro/glyphmaps/FontAwesome5Pro_meta.json';
 import { FontAwesome6 } from '@react-native-vector-icons/fontawesome6';
-// @ts-expect-error: We don't really want to export this
 import FontAwesome6Glyphs from '@react-native-vector-icons/fontawesome6/glyphmaps/FontAwesome6.json';
-// @ts-expect-error: We don't really want to export this
 import FontAwesome6Meta from '@react-native-vector-icons/fontawesome6/glyphmaps/FontAwesome6_meta.json';
 import { FontAwesome6Pro } from '@react-native-vector-icons/fontawesome6-pro';
-// @ts-expect-error: We don't really want to export this
 import FontAwesome6ProGlyphs from '@react-native-vector-icons/fontawesome6-pro/glyphmaps/FontAwesome6Pro.json';
-// @ts-expect-error: We don't really want to export this
 import FontAwesome6ProMeta from '@react-native-vector-icons/fontawesome6-pro/glyphmaps/FontAwesome6Pro_meta.json';
 import createFontelloIconSet from '@react-native-vector-icons/fontello';
 import { Fontisto } from '@react-native-vector-icons/fontisto';
-// @ts-expect-error: We don't really want to export this
 import FontistoGlyphs from '@react-native-vector-icons/fontisto/glyphmaps/Fontisto.json';
 import { Foundation } from '@react-native-vector-icons/foundation';
-// @ts-expect-error: We don't really want to export this
 import FoundationGlyphs from '@react-native-vector-icons/foundation/glyphmaps/Foundation.json';
 import createIcoMoonIconSet from '@react-native-vector-icons/icomoon';
 import { Ionicons } from '@react-native-vector-icons/ionicons';
-// @ts-expect-error: We don't really want to export this
 import IoniconsGlyphs from '@react-native-vector-icons/ionicons/glyphmaps/Ionicons.json';
 import { Lucide } from '@react-native-vector-icons/lucide';
-// @ts-expect-error: We don't really want to export this
 import LucideGlyphs from '@react-native-vector-icons/lucide/glyphmaps/Lucide.json';
 import { MaterialDesignIcons } from '@react-native-vector-icons/material-design-icons';
-// @ts-expect-error: We don't really want to export this
 import MaterialDesignIconsGlyphs from '@react-native-vector-icons/material-design-icons/glyphmaps/MaterialDesignIcons.json';
 import { MaterialIcons } from '@react-native-vector-icons/material-icons';
-// @ts-expect-error: We don't really want to export this
 import MaterialIconsGlyphs from '@react-native-vector-icons/material-icons/glyphmaps/MaterialIcons.json';
 import { Octicons } from '@react-native-vector-icons/octicons';
-// @ts-expect-error: We don't really want to export this
 import OcticonsGlyphs from '@react-native-vector-icons/octicons/glyphmaps/Octicons.json';
 import { SimpleLineIcons } from '@react-native-vector-icons/simple-line-icons';
-// @ts-expect-error: We don't really want to export this
 import SimpleLineIconsGlyphs from '@react-native-vector-icons/simple-line-icons/glyphmaps/SimpleLineIcons.json';
 import { Zocial } from '@react-native-vector-icons/zocial';
-// @ts-expect-error: We don't really want to export this
 import ZocialGlyphs from '@react-native-vector-icons/zocial/glyphmaps/Zocial.json';
 
 import FontelloConfig from './configs/fontello.config.json';

--- a/packages/ionicons/package.json
+++ b/packages/ionicons/package.json
@@ -16,7 +16,9 @@
         "types": "./lib/typescript/commonjs/src/index.d.ts",
         "default": "./lib/commonjs/index.js"
       }
-    }
+    },
+    "./glyphmaps/*.json": "./glyphmaps/*.json",
+    "./fonts/*.ttf": "./fonts/*.ttf"
   },
   "files": [
     "src",

--- a/packages/lucide/package.json
+++ b/packages/lucide/package.json
@@ -16,7 +16,9 @@
         "types": "./lib/typescript/commonjs/src/index.d.ts",
         "default": "./lib/commonjs/index.js"
       }
-    }
+    },
+    "./glyphmaps/*.json": "./glyphmaps/*.json",
+    "./fonts/*.ttf": "./fonts/*.ttf"
   },
   "files": [
     "src",

--- a/packages/material-design-icons/package.json
+++ b/packages/material-design-icons/package.json
@@ -16,7 +16,9 @@
         "types": "./lib/typescript/commonjs/src/index.d.ts",
         "default": "./lib/commonjs/index.js"
       }
-    }
+    },
+    "./glyphmaps/*.json": "./glyphmaps/*.json",
+    "./fonts/*.ttf": "./fonts/*.ttf"
   },
   "files": [
     "src",

--- a/packages/material-icons/package.json
+++ b/packages/material-icons/package.json
@@ -16,7 +16,9 @@
         "types": "./lib/typescript/commonjs/src/index.d.ts",
         "default": "./lib/commonjs/index.js"
       }
-    }
+    },
+    "./glyphmaps/*.json": "./glyphmaps/*.json",
+    "./fonts/*.ttf": "./fonts/*.ttf"
   },
   "files": [
     "src",

--- a/packages/octicons/package.json
+++ b/packages/octicons/package.json
@@ -16,7 +16,9 @@
         "types": "./lib/typescript/commonjs/src/index.d.ts",
         "default": "./lib/commonjs/index.js"
       }
-    }
+    },
+    "./glyphmaps/*.json": "./glyphmaps/*.json",
+    "./fonts/*.ttf": "./fonts/*.ttf"
   },
   "files": [
     "src",

--- a/packages/simple-line-icons/package.json
+++ b/packages/simple-line-icons/package.json
@@ -16,7 +16,9 @@
         "types": "./lib/typescript/commonjs/src/index.d.ts",
         "default": "./lib/commonjs/index.js"
       }
-    }
+    },
+    "./glyphmaps/*.json": "./glyphmaps/*.json",
+    "./fonts/*.ttf": "./fonts/*.ttf"
   },
   "files": [
     "src",

--- a/packages/zocial/package.json
+++ b/packages/zocial/package.json
@@ -16,7 +16,9 @@
         "types": "./lib/typescript/commonjs/src/index.d.ts",
         "default": "./lib/commonjs/index.js"
       }
-    }
+    },
+    "./glyphmaps/*.json": "./glyphmaps/*.json",
+    "./fonts/*.ttf": "./fonts/*.ttf"
   },
   "files": [
     "src",


### PR DESCRIPTION
This allows consumers to import ttf files and glyphmaps.

Importing these are valid uses cases as demonstrated by https://github.com/oblador/react-native-vector-icons/issues/1785 and by the `icon-explorer` demo app.

closes #1785, closes #1825