### PR TITLE
feat: support dynamic font loading in icomoon and fontello

### DIFF
--- a/packages/common/src/create-icon-set.tsx
+++ b/packages/common/src/create-icon-set.tsx
@@ -25,7 +25,7 @@ export type IconProps<T> = TextProps & {
   innerRef?: Ref<Text>;
 };
 
-type IconComponent<GM extends Record<string, number>> = React.FC<
+export type IconComponent<GM extends Record<string, number>> = React.FC<
   TextProps & {
     name: keyof GM;
     size?: number;
@@ -150,7 +150,7 @@ export function createIconSet<GM extends Record<string, number>>(
   const WrappedIcon = forwardRef<Text, IconProps<keyof typeof glyphMap>>((props, ref) => (
     <Icon innerRef={ref} {...props} />
   ));
-  WrappedIcon.displayName = 'Icon';
+  WrappedIcon.displayName = `Icon(${postScriptName})`;
 
   const imageSourceCache = createIconSourceCache();
 

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -1,4 +1,4 @@
-export type { CreateIconSetOptions, IconProps } from './create-icon-set';
+export type { CreateIconSetOptions, IconComponent, IconProps } from './create-icon-set';
 export { createIconSet } from './create-icon-set';
 export { DEFAULT_ICON_COLOR, DEFAULT_ICON_SIZE } from './defaults';
 export {

--- a/packages/fontello/README.md
+++ b/packages/fontello/README.md
@@ -27,7 +27,7 @@ import createIconSet from '@react-native-vector-icons/fontello';
 import fontelloConfig from './config.json';
 const Icon = createIconSet(fontelloConfig);
 
-cont icon = <Icon name="comments" />;
+const icon = <Icon name="comments" />;
 ```
 
 If you want to customise the font postscript name and filename you can pass extra arguments.

--- a/packages/fontello/src/index.ts
+++ b/packages/fontello/src/index.ts
@@ -3,7 +3,7 @@
  * Usage: <Fontello name="icon-name" size={20} color="#4F8EF7" />
  */
 
-import { createIconSet } from '@react-native-vector-icons/common';
+import { type CreateIconSetOptions, createIconSet, type IconComponent } from '@react-native-vector-icons/common';
 
 type FontelloConfig = {
   name: string;
@@ -20,13 +20,41 @@ type FontelloConfig = {
   }>;
 };
 
-export default function createIconSetFromFontello(config: FontelloConfig, fontFamilyArg?: string, fontFile?: string) {
+type FontelloComponent = IconComponent<Record<string, number>>;
+
+// entries are optional because they can be derived from the config
+type Options = Partial<CreateIconSetOptions>;
+
+export default function createIconSetFromFontello(
+  config: FontelloConfig,
+  postScriptName?: string,
+  fontFileName?: string,
+): FontelloComponent;
+export default function createIconSetFromFontello(config: FontelloConfig, options: Options): FontelloComponent;
+export default function createIconSetFromFontello(
+  config: FontelloConfig,
+  postScriptNameOrOptions?: string | Options,
+  fontFileNameParam?: string,
+): FontelloComponent {
+  const { postScriptName, fontFileName, fontSource, fontStyle } =
+    typeof postScriptNameOrOptions === 'object'
+      ? postScriptNameOrOptions
+      : {
+          postScriptName: postScriptNameOrOptions,
+          fontFileName: fontFileNameParam,
+        };
+
   const glyphMap: Record<string, number> = {};
   config.glyphs.forEach((glyph) => {
     glyphMap[glyph.css] = glyph.code;
   });
 
-  const fontFamily = fontFamilyArg || config.name || 'fontello';
+  const fontFamily = postScriptName || config.name || 'fontello';
 
-  return createIconSet(glyphMap, fontFamily, fontFile || `${fontFamily}.ttf`);
+  return createIconSet(glyphMap, {
+    postScriptName: fontFamily,
+    fontFileName: fontFileName || `${fontFamily}.ttf`,
+    fontSource,
+    fontStyle,
+  });
 }

--- a/packages/icomoon/README.md
+++ b/packages/icomoon/README.md
@@ -27,7 +27,7 @@ import createIconSet from '@react-native-vector-icons/icomoon';
 import icoMoonConfig from './IcoMoon-Free.json';
 const Icon = createIconSet(icoMoonConfig);
 
-cont icon = <Icon name="comments" />;
+const icon = <Icon name="comments" />;
 ```
 
 If you want to customise the font postscript name and filename you can pass extra arguments.

--- a/packages/icomoon/src/index.ts
+++ b/packages/icomoon/src/index.ts
@@ -3,7 +3,7 @@
  * Usage: <Fontello name="icon-name" size={20} color="#4F8EF7" />
  */
 
-import { createIconSet } from '@react-native-vector-icons/common';
+import { type CreateIconSetOptions, createIconSet, type IconComponent } from '@react-native-vector-icons/common';
 
 type IcoMoonIcon = {
   properties: {
@@ -22,7 +22,30 @@ type IcoMoonConfig = {
   };
 };
 
-export default function createIconSetFromIcoMoon(config: IcoMoonConfig, fontFamilyArg?: string, fontFile?: string) {
+type IcoMoonComponent = IconComponent<Record<string, number>>;
+
+// entries are optional because they can be derived from the config
+type Options = Partial<CreateIconSetOptions>;
+
+export default function createIconSetFromIcoMoon(
+  config: IcoMoonConfig,
+  postScriptName?: string,
+  fontFileName?: string,
+): IcoMoonComponent;
+export default function createIconSetFromIcoMoon(config: IcoMoonConfig, options: Options): IcoMoonComponent;
+export default function createIconSetFromIcoMoon(
+  config: IcoMoonConfig,
+  postScriptNameOrOptions?: string | Options,
+  fontFileNameParam?: string,
+): IcoMoonComponent {
+  const { postScriptName, fontFileName, fontSource, fontStyle } =
+    typeof postScriptNameOrOptions === 'object'
+      ? postScriptNameOrOptions
+      : {
+          postScriptName: postScriptNameOrOptions,
+          fontFileName: fontFileNameParam,
+        };
+
   const glyphMap: Record<string, number> = {};
   config.icons.forEach((icon) => {
     icon.properties.name.split(/\s*,\s*/g).forEach((name) => {
@@ -30,7 +53,12 @@ export default function createIconSetFromIcoMoon(config: IcoMoonConfig, fontFami
     });
   });
 
-  const fontFamily = fontFamilyArg || config.preferences.fontPref.metadata.fontFamily;
+  const fontFamily = postScriptName || config.preferences.fontPref.metadata.fontFamily;
 
-  return createIconSet(glyphMap, fontFamily, fontFile || `${fontFamily}.ttf`);
+  return createIconSet(glyphMap, {
+    postScriptName: fontFamily,
+    fontFileName: fontFileName || `${fontFamily}.ttf`,
+    fontSource,
+    fontStyle,
+  });
 }


### PR DESCRIPTION
`createIconSet` from the `common` package has two supported signatures: https://github.com/oblador/react-native-vector-icons/blob/4ac93f86fd2815b8b4ba01851041d9239c26f3a8/packages/common/src/create-icon-set.tsx#L47

the second signature support dynamic font loading: https://github.com/oblador/react-native-vector-icons/blob/4ac93f86fd2815b8b4ba01851041d9239c26f3a8/packages/common/src/create-icon-set.tsx#L53

the `icoMoon` and `fontello` packages so far shipped with only the first (old) signature and this allows them to be used for dynamic loading of the custom fonts. This is especially useful in the context of Expo Go.