### PR TITLE
chore: update bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,7 +1,6 @@
 ---
 name: "\U0001F41B Bug report"
 description: Report a bug
-title: "[Bug]: "
 labels: ["bug", "triage"]
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,8 +1,7 @@
 ---
 name: Feature request
 description: Suggest an idea for this project
-title: "[Feature]: "
-labels: ["feature", "triage"]
+labels: ["feature request", "triage"]
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
when all bug reports in the issue tracker start with "[Bug]:" then there's little value in that. We might as well drop it. There's also the "bug" label.