### PR TITLE
fix: correct required node version

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -100,7 +100,7 @@
     }
   },
   "engines": {
-    "node": ">= 18.0.0"
+    "node": ">= 20.19.0"
   },
   "jest": {
     "preset": "react-native",

--- a/packages/common/src/scripts/common.ts
+++ b/packages/common/src/scripts/common.ts
@@ -4,7 +4,7 @@ import path from 'node:path';
 import { findUpSync } from 'find-up';
 
 /**
- * Source vendored and simplified from @react-native-coommunity/cli
+ * Source vendored and simplified from @react-native-community/cli
  */
 const resolveNodeModuleDir = (root: string, pkgName: string) => {
   const packageDir = findUpSync(path.join('node_modules', pkgName), {


### PR DESCRIPTION
fix for https://github.com/oblador/react-native-vector-icons/issues/1835

see: https://nodejs.org/en/blog/release/v20.19.0