### PR TITLE
Add docs on edge case that breaks font loading iOS + expo

### DIFF
--- a/docs/SETUP-EXPO.md
+++ b/docs/SETUP-EXPO.md
@@ -6,3 +6,15 @@ Icon packages from `@react-native-vector-icons` work out of the box with Expo, a
 
 > [!WARNING]  
 > Avoid Manual Font Duplication: do not add fonts from `node_modules/@react-native-vector-icons/some-font` to `expo-font` plugin configuration unless you have a specific advanced use case.
+
+
+> [!Troubleshooting]  
+> Icons are not showing on iOS:  
+> The order of imports at your app's entry point is important. Import `expo` or `expo-router` before importing this one. If this library is imported before Expo is initialized, icons may not display correctly.
+> ```javascript
+> // Import Expo first, before your App component
+> import { registerRootComponent } from 'expo'; 
+> import App from './App';
+> 
+> registerRootComponent(App);
+> ```


### PR DESCRIPTION
I had an Issue after migrating from an ancient Version.
On iOS the Icons were not shown (on dev Builds).
After a lot of debugging I found the issue.
In the App entry point (index.js) the main App Component was imported before expo.
The order of imports broke font loading.

```javascript
import App from './App'; //<-- importing this before expo broke the Icon loading
import { registerRootComponent } from 'expo'; 

registerRootComponent(App);
```
This is probably a rare edge cases but not easy to debug & solve.

Another workaround was to call the `rnvi-update-plist` because then the fonts were already included at compile time and dynamic loading was needed.

==> This PR adds a warning for this (probably rare) Edge cases.

