### PR TITLE
fix: update codemod simple-line-icon repository name

### DIFF
--- a/packages/codemod/src/expo/import-transform.ts
+++ b/packages/codemod/src/expo/import-transform.ts
@@ -18,7 +18,7 @@ const importsMap: Record<string, string> = {
   '@expo/vector-icons/MaterialCommunityIcons': '@react-native-vector-icons/material-design-icons',
   '@expo/vector-icons/MaterialIcons': '@react-native-vector-icons/material-icons',
   '@expo/vector-icons/Octicons': '@react-native-vector-icons/octicons',
-  '@expo/vector-icons/SimpleLineIcons': '@react-native-vector-icons/SimpleLineIcons',
+  '@expo/vector-icons/SimpleLineIcons': '@react-native-vector-icons/simple-line-icons',
   '@expo/vector-icons/Zocial': '@react-native-vector-icons/zocial',
   // non-icon-family imports
   '@expo/vector-icons/createIconSetFromIcoMoon': '@react-native-vector-icons/icomoon',


### PR DESCRIPTION
As mentioned in #1855 the repository name for `simple-line-icons` should be updated to make codemod working again.