### PR TITLE
fix: add defaultConfig for targetSdkVersion and minSdkVersion

### DIFF
--- a/packages/ant-design/android/build.gradle
+++ b/packages/ant-design/android/build.gradle
@@ -37,6 +37,11 @@ android {
   }
 
   compileSdkVersion safeExtGet('compileSdkVersion', 31)
+
+  defaultConfig {
+    targetSdkVersion safeExtGet('targetSdkVersion', 31)
+    minSdkVersion safeExtGet('minSdkVersion', 24)
+  }
 }
 
 dependencies {

--- a/packages/entypo/android/build.gradle
+++ b/packages/entypo/android/build.gradle
@@ -37,6 +37,11 @@ android {
   }
 
   compileSdkVersion safeExtGet('compileSdkVersion', 31)
+
+  defaultConfig {
+    targetSdkVersion safeExtGet('targetSdkVersion', 31)
+    minSdkVersion safeExtGet('minSdkVersion', 24)
+  }
 }
 
 dependencies {

--- a/packages/evil-icons/android/build.gradle
+++ b/packages/evil-icons/android/build.gradle
@@ -37,6 +37,11 @@ android {
   }
 
   compileSdkVersion safeExtGet('compileSdkVersion', 31)
+
+  defaultConfig {
+    targetSdkVersion safeExtGet('targetSdkVersion', 31)
+    minSdkVersion safeExtGet('minSdkVersion', 24)
+  }
 }
 
 dependencies {

--- a/packages/feather/android/build.gradle
+++ b/packages/feather/android/build.gradle
@@ -37,6 +37,11 @@ android {
   }
 
   compileSdkVersion safeExtGet('compileSdkVersion', 31)
+
+  defaultConfig {
+    targetSdkVersion safeExtGet('targetSdkVersion', 31)
+    minSdkVersion safeExtGet('minSdkVersion', 24)
+  }
 }
 
 dependencies {

--- a/packages/fontawesome-free-brands/android/build.gradle
+++ b/packages/fontawesome-free-brands/android/build.gradle
@@ -37,6 +37,11 @@ android {
   }
 
   compileSdkVersion safeExtGet('compileSdkVersion', 31)
+
+  defaultConfig {
+    targetSdkVersion safeExtGet('targetSdkVersion', 31)
+    minSdkVersion safeExtGet('minSdkVersion', 24)
+  }
 }
 
 dependencies {

--- a/packages/fontawesome-free-regular/android/build.gradle
+++ b/packages/fontawesome-free-regular/android/build.gradle
@@ -37,6 +37,11 @@ android {
   }
 
   compileSdkVersion safeExtGet('compileSdkVersion', 31)
+
+  defaultConfig {
+    targetSdkVersion safeExtGet('targetSdkVersion', 31)
+    minSdkVersion safeExtGet('minSdkVersion', 24)
+  }
 }
 
 dependencies {

--- a/packages/fontawesome-free-solid/android/build.gradle
+++ b/packages/fontawesome-free-solid/android/build.gradle
@@ -37,6 +37,11 @@ android {
   }
 
   compileSdkVersion safeExtGet('compileSdkVersion', 31)
+
+  defaultConfig {
+    targetSdkVersion safeExtGet('targetSdkVersion', 31)
+    minSdkVersion safeExtGet('minSdkVersion', 24)
+  }
 }
 
 dependencies {

--- a/packages/fontawesome-pro-brands/android/build.gradle
+++ b/packages/fontawesome-pro-brands/android/build.gradle
@@ -37,6 +37,11 @@ android {
   }
 
   compileSdkVersion safeExtGet('compileSdkVersion', 31)
+
+  defaultConfig {
+    targetSdkVersion safeExtGet('targetSdkVersion', 31)
+    minSdkVersion safeExtGet('minSdkVersion', 24)
+  }
 }
 
 dependencies {

--- a/packages/fontawesome-pro-duotone-light/android/build.gradle
+++ b/packages/fontawesome-pro-duotone-light/android/build.gradle
@@ -37,6 +37,11 @@ android {
   }
 
   compileSdkVersion safeExtGet('compileSdkVersion', 31)
+
+  defaultConfig {
+    targetSdkVersion safeExtGet('targetSdkVersion', 31)
+    minSdkVersion safeExtGet('minSdkVersion', 24)
+  }
 }
 
 dependencies {

--- a/packages/fontawesome-pro-duotone-regular/android/build.gradle
+++ b/packages/fontawesome-pro-duotone-regular/android/build.gradle
@@ -37,6 +37,11 @@ android {
   }
 
   compileSdkVersion safeExtGet('compileSdkVersion', 31)
+
+  defaultConfig {
+    targetSdkVersion safeExtGet('targetSdkVersion', 31)
+    minSdkVersion safeExtGet('minSdkVersion', 24)
+  }
 }
 
 dependencies {

--- a/packages/fontawesome-pro-duotone-solid/android/build.gradle
+++ b/packages/fontawesome-pro-duotone-solid/android/build.gradle
@@ -37,6 +37,11 @@ android {
   }
 
   compileSdkVersion safeExtGet('compileSdkVersion', 31)
+
+  defaultConfig {
+    targetSdkVersion safeExtGet('targetSdkVersion', 31)
+    minSdkVersion safeExtGet('minSdkVersion', 24)
+  }
 }
 
 dependencies {

--- a/packages/fontawesome-pro-duotone-thin/android/build.gradle
+++ b/packages/fontawesome-pro-duotone-thin/android/build.gradle
@@ -37,6 +37,11 @@ android {
   }
 
   compileSdkVersion safeExtGet('compileSdkVersion', 31)
+
+  defaultConfig {
+    targetSdkVersion safeExtGet('targetSdkVersion', 31)
+    minSdkVersion safeExtGet('minSdkVersion', 24)
+  }
 }
 
 dependencies {

--- a/packages/fontawesome-pro-light/android/build.gradle
+++ b/packages/fontawesome-pro-light/android/build.gradle
@@ -37,6 +37,11 @@ android {
   }
 
   compileSdkVersion safeExtGet('compileSdkVersion', 31)
+
+  defaultConfig {
+    targetSdkVersion safeExtGet('targetSdkVersion', 31)
+    minSdkVersion safeExtGet('minSdkVersion', 24)
+  }
 }
 
 dependencies {

--- a/packages/fontawesome-pro-regular/android/build.gradle
+++ b/packages/fontawesome-pro-regular/android/build.gradle
@@ -37,6 +37,11 @@ android {
   }
 
   compileSdkVersion safeExtGet('compileSdkVersion', 31)
+
+  defaultConfig {
+    targetSdkVersion safeExtGet('targetSdkVersion', 31)
+    minSdkVersion safeExtGet('minSdkVersion', 24)
+  }
 }
 
 dependencies {

--- a/packages/fontawesome-pro-sharp-duotone-light/android/build.gradle
+++ b/packages/fontawesome-pro-sharp-duotone-light/android/build.gradle
@@ -37,6 +37,11 @@ android {
   }
 
   compileSdkVersion safeExtGet('compileSdkVersion', 31)
+
+  defaultConfig {
+    targetSdkVersion safeExtGet('targetSdkVersion', 31)
+    minSdkVersion safeExtGet('minSdkVersion', 24)
+  }
 }
 
 dependencies {

--- a/packages/fontawesome-pro-sharp-duotone-regular/android/build.gradle
+++ b/packages/fontawesome-pro-sharp-duotone-regular/android/build.gradle
@@ -37,6 +37,11 @@ android {
   }
 
   compileSdkVersion safeExtGet('compileSdkVersion', 31)
+
+  defaultConfig {
+    targetSdkVersion safeExtGet('targetSdkVersion', 31)
+    minSdkVersion safeExtGet('minSdkVersion', 24)
+  }
 }
 
 dependencies {

--- a/packages/fontawesome-pro-sharp-duotone-solid/android/build.gradle
+++ b/packages/fontawesome-pro-sharp-duotone-solid/android/build.gradle
@@ -37,6 +37,11 @@ android {
   }
 
   compileSdkVersion safeExtGet('compileSdkVersion', 31)
+
+  defaultConfig {
+    targetSdkVersion safeExtGet('targetSdkVersion', 31)
+    minSdkVersion safeExtGet('minSdkVersion', 24)
+  }
 }
 
 dependencies {

--- a/packages/fontawesome-pro-sharp-duotone-thin/android/build.gradle
+++ b/packages/fontawesome-pro-sharp-duotone-thin/android/build.gradle
@@ -37,6 +37,11 @@ android {
   }
 
   compileSdkVersion safeExtGet('compileSdkVersion', 31)
+
+  defaultConfig {
+    targetSdkVersion safeExtGet('targetSdkVersion', 31)
+    minSdkVersion safeExtGet('minSdkVersion', 24)
+  }
 }
 
 dependencies {

--- a/packages/fontawesome-pro-sharp-light/android/build.gradle
+++ b/packages/fontawesome-pro-sharp-light/android/build.gradle
@@ -37,6 +37,11 @@ android {
   }
 
   compileSdkVersion safeExtGet('compileSdkVersion', 31)
+
+  defaultConfig {
+    targetSdkVersion safeExtGet('targetSdkVersion', 31)
+    minSdkVersion safeExtGet('minSdkVersion', 24)
+  }
 }
 
 dependencies {

--- a/packages/fontawesome-pro-sharp-regular/android/build.gradle
+++ b/packages/fontawesome-pro-sharp-regular/android/build.gradle
@@ -37,6 +37,11 @@ android {
   }
 
   compileSdkVersion safeExtGet('compileSdkVersion', 31)
+
+  defaultConfig {
+    targetSdkVersion safeExtGet('targetSdkVersion', 31)
+    minSdkVersion safeExtGet('minSdkVersion', 24)
+  }
 }
 
 dependencies {

--- a/packages/fontawesome-pro-sharp-solid/android/build.gradle
+++ b/packages/fontawesome-pro-sharp-solid/android/build.gradle
@@ -37,6 +37,11 @@ android {
   }
 
   compileSdkVersion safeExtGet('compileSdkVersion', 31)
+
+  defaultConfig {
+    targetSdkVersion safeExtGet('targetSdkVersion', 31)
+    minSdkVersion safeExtGet('minSdkVersion', 24)
+  }
 }
 
 dependencies {

--- a/packages/fontawesome-pro-sharp-thin/android/build.gradle
+++ b/packages/fontawesome-pro-sharp-thin/android/build.gradle
@@ -37,6 +37,11 @@ android {
   }
 
   compileSdkVersion safeExtGet('compileSdkVersion', 31)
+
+  defaultConfig {
+    targetSdkVersion safeExtGet('targetSdkVersion', 31)
+    minSdkVersion safeExtGet('minSdkVersion', 24)
+  }
 }
 
 dependencies {

--- a/packages/fontawesome-pro-solid/android/build.gradle
+++ b/packages/fontawesome-pro-solid/android/build.gradle
@@ -37,6 +37,11 @@ android {
   }
 
   compileSdkVersion safeExtGet('compileSdkVersion', 31)
+
+  defaultConfig {
+    targetSdkVersion safeExtGet('targetSdkVersion', 31)
+    minSdkVersion safeExtGet('minSdkVersion', 24)
+  }
 }
 
 dependencies {

--- a/packages/fontawesome-pro-thin/android/build.gradle
+++ b/packages/fontawesome-pro-thin/android/build.gradle
@@ -37,6 +37,11 @@ android {
   }
 
   compileSdkVersion safeExtGet('compileSdkVersion', 31)
+
+  defaultConfig {
+    targetSdkVersion safeExtGet('targetSdkVersion', 31)
+    minSdkVersion safeExtGet('minSdkVersion', 24)
+  }
 }
 
 dependencies {

--- a/packages/fontawesome/android/build.gradle
+++ b/packages/fontawesome/android/build.gradle
@@ -37,6 +37,11 @@ android {
   }
 
   compileSdkVersion safeExtGet('compileSdkVersion', 31)
+
+  defaultConfig {
+    targetSdkVersion safeExtGet('targetSdkVersion', 31)
+    minSdkVersion safeExtGet('minSdkVersion', 24)
+  }
 }
 
 dependencies {

--- a/packages/fontawesome5-pro/android/build.gradle
+++ b/packages/fontawesome5-pro/android/build.gradle
@@ -37,6 +37,11 @@ android {
   }
 
   compileSdkVersion safeExtGet('compileSdkVersion', 31)
+
+  defaultConfig {
+    targetSdkVersion safeExtGet('targetSdkVersion', 31)
+    minSdkVersion safeExtGet('minSdkVersion', 24)
+  }
 }
 
 dependencies {

--- a/packages/fontawesome5/android/build.gradle
+++ b/packages/fontawesome5/android/build.gradle
@@ -37,6 +37,11 @@ android {
   }
 
   compileSdkVersion safeExtGet('compileSdkVersion', 31)
+
+  defaultConfig {
+    targetSdkVersion safeExtGet('targetSdkVersion', 31)
+    minSdkVersion safeExtGet('minSdkVersion', 24)
+  }
 }
 
 dependencies {

--- a/packages/fontawesome6-pro/android/build.gradle
+++ b/packages/fontawesome6-pro/android/build.gradle
@@ -37,6 +37,11 @@ android {
   }
 
   compileSdkVersion safeExtGet('compileSdkVersion', 31)
+
+  defaultConfig {
+    targetSdkVersion safeExtGet('targetSdkVersion', 31)
+    minSdkVersion safeExtGet('minSdkVersion', 24)
+  }
 }
 
 dependencies {

--- a/packages/fontawesome6/android/build.gradle
+++ b/packages/fontawesome6/android/build.gradle
@@ -37,6 +37,11 @@ android {
   }
 
   compileSdkVersion safeExtGet('compileSdkVersion', 31)
+
+  defaultConfig {
+    targetSdkVersion safeExtGet('targetSdkVersion', 31)
+    minSdkVersion safeExtGet('minSdkVersion', 24)
+  }
 }
 
 dependencies {

--- a/packages/fontello/android/build.gradle
+++ b/packages/fontello/android/build.gradle
@@ -37,6 +37,11 @@ android {
   }
 
   compileSdkVersion safeExtGet('compileSdkVersion', 31)
+
+  defaultConfig {
+    targetSdkVersion safeExtGet('targetSdkVersion', 31)
+    minSdkVersion safeExtGet('minSdkVersion', 24)
+  }
 }
 
 dependencies {

--- a/packages/fontisto/android/build.gradle
+++ b/packages/fontisto/android/build.gradle
@@ -37,6 +37,11 @@ android {
   }
 
   compileSdkVersion safeExtGet('compileSdkVersion', 31)
+
+  defaultConfig {
+    targetSdkVersion safeExtGet('targetSdkVersion', 31)
+    minSdkVersion safeExtGet('minSdkVersion', 24)
+  }
 }
 
 dependencies {

--- a/packages/foundation/android/build.gradle
+++ b/packages/foundation/android/build.gradle
@@ -37,6 +37,11 @@ android {
   }
 
   compileSdkVersion safeExtGet('compileSdkVersion', 31)
+
+  defaultConfig {
+    targetSdkVersion safeExtGet('targetSdkVersion', 31)
+    minSdkVersion safeExtGet('minSdkVersion', 24)
+  }
 }
 
 dependencies {

--- a/packages/generator-react-native-vector-icons/src/app/templates/android/build.gradle
+++ b/packages/generator-react-native-vector-icons/src/app/templates/android/build.gradle
@@ -37,6 +37,11 @@ android {
   }
 
   compileSdkVersion safeExtGet('compileSdkVersion', 31)
+
+  defaultConfig {
+    targetSdkVersion safeExtGet('targetSdkVersion', 31)
+    minSdkVersion safeExtGet('minSdkVersion', 24)
+  }
 }
 
 dependencies {

--- a/packages/icomoon/android/build.gradle
+++ b/packages/icomoon/android/build.gradle
@@ -37,6 +37,11 @@ android {
   }
 
   compileSdkVersion safeExtGet('compileSdkVersion', 31)
+
+  defaultConfig {
+    targetSdkVersion safeExtGet('targetSdkVersion', 31)
+    minSdkVersion safeExtGet('minSdkVersion', 24)
+  }
 }
 
 dependencies {

--- a/packages/ionicons/android/build.gradle
+++ b/packages/ionicons/android/build.gradle
@@ -37,6 +37,11 @@ android {
   }
 
   compileSdkVersion safeExtGet('compileSdkVersion', 31)
+
+  defaultConfig {
+    targetSdkVersion safeExtGet('targetSdkVersion', 31)
+    minSdkVersion safeExtGet('minSdkVersion', 24)
+  }
 }
 
 dependencies {

--- a/packages/lucide/android/build.gradle
+++ b/packages/lucide/android/build.gradle
@@ -37,6 +37,11 @@ android {
   }
 
   compileSdkVersion safeExtGet('compileSdkVersion', 31)
+
+  defaultConfig {
+    targetSdkVersion safeExtGet('targetSdkVersion', 31)
+    minSdkVersion safeExtGet('minSdkVersion', 24)
+  }
 }
 
 dependencies {

--- a/packages/material-design-icons/android/build.gradle
+++ b/packages/material-design-icons/android/build.gradle
@@ -37,6 +37,11 @@ android {
   }
 
   compileSdkVersion safeExtGet('compileSdkVersion', 31)
+
+  defaultConfig {
+    targetSdkVersion safeExtGet('targetSdkVersion', 31)
+    minSdkVersion safeExtGet('minSdkVersion', 24)
+  }
 }
 
 dependencies {

--- a/packages/material-icons/android/build.gradle
+++ b/packages/material-icons/android/build.gradle
@@ -37,6 +37,11 @@ android {
   }
 
   compileSdkVersion safeExtGet('compileSdkVersion', 31)
+
+  defaultConfig {
+    targetSdkVersion safeExtGet('targetSdkVersion', 31)
+    minSdkVersion safeExtGet('minSdkVersion', 24)
+  }
 }
 
 dependencies {

--- a/packages/octicons/android/build.gradle
+++ b/packages/octicons/android/build.gradle
@@ -37,6 +37,11 @@ android {
   }
 
   compileSdkVersion safeExtGet('compileSdkVersion', 31)
+
+  defaultConfig {
+    targetSdkVersion safeExtGet('targetSdkVersion', 31)
+    minSdkVersion safeExtGet('minSdkVersion', 24)
+  }
 }
 
 dependencies {

--- a/packages/simple-line-icons/android/build.gradle
+++ b/packages/simple-line-icons/android/build.gradle
@@ -37,6 +37,11 @@ android {
   }
 
   compileSdkVersion safeExtGet('compileSdkVersion', 31)
+
+  defaultConfig {
+    targetSdkVersion safeExtGet('targetSdkVersion', 31)
+    minSdkVersion safeExtGet('minSdkVersion', 24)
+  }
 }
 
 dependencies {

--- a/packages/zocial/android/build.gradle
+++ b/packages/zocial/android/build.gradle
@@ -37,6 +37,11 @@ android {
   }
 
   compileSdkVersion safeExtGet('compileSdkVersion', 31)
+
+  defaultConfig {
+    targetSdkVersion safeExtGet('targetSdkVersion', 31)
+    minSdkVersion safeExtGet('minSdkVersion', 24)
+  }
 }
 
 dependencies {


### PR DESCRIPTION
fix #1861

Specifying targetSdkVersion will prevent some dangerous permission being added into `AndroidManifest.xml` by gradle.