### PR TITLE
chore: add npm trust setup and publish status check scripts

### DIFF
--- a/packages/generator-react-native-vector-icons/package.json
+++ b/packages/generator-react-native-vector-icons/package.json
@@ -37,5 +37,14 @@
     "watch": "npm run watch-tsc --silent & npm run watch-deps --silent",
     "watch-deps": "onchange 'src/*/templates/**' 'src/*/fontforge/**' --initial -- pnpm run copydeps",
     "watch-tsc": "tsc -w"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/oblador/react-native-vector-icons.git",
+    "directory": "packages/generator-react-native-vector-icons"
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
   }
 }

--- a/scripts/check-npm-publish-status.sh
+++ b/scripts/check-npm-publish-status.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+YELLOW='\033[0;33m'
+BOLD='\033[1m'
+RESET='\033[0m'
+
+published=0
+not_published=0
+skipped_private=0
+not_published_packages=()
+
+for pkg_json in packages/*/package.json; do
+  private=$(jq -r '.private // false' "$pkg_json")
+  name=$(jq -r '.name' "$pkg_json")
+  version=$(jq -r '.version' "$pkg_json")
+
+  if [ "$private" = "true" ]; then
+    echo -e "${YELLOW}SKIP (private):${RESET} $name"
+    skipped_private=$((skipped_private + 1))
+    continue
+  fi
+
+  echo -n "Checking $name@$version ... "
+
+  if npm view "$name@$version" version >/dev/null 2>&1; then
+    echo -e "${GREEN}published${RESET}"
+    published=$((published + 1))
+  else
+    echo -e "${RED}NOT PUBLISHED${RESET}"
+    not_published=$((not_published + 1))
+    not_published_packages+=("$name@$version")
+  fi
+done
+
+echo ""
+echo -e "${BOLD}=== Summary ===${RESET}"
+echo -e "${GREEN}Published:${RESET}         $published"
+echo -e "${RED}Not published:${RESET}     $not_published"
+echo -e "${YELLOW}Skipped (private):${RESET} $skipped_private"
+
+if [ ${#not_published_packages[@]} -gt 0 ]; then
+  echo ""
+  echo -e "${RED}Not published:${RESET}"
+  for pkg in "${not_published_packages[@]}"; do
+    echo -e "  - ${RED}$pkg${RESET}"
+  done
+fi

--- a/scripts/setup-npm-trust.sh
+++ b/scripts/setup-npm-trust.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO="oblador/react-native-vector-icons"
+WORKFLOW_FILE="deploy.yaml"
+
+already_configured=0
+newly_configured=0
+failed=0
+skipped_private=0
+failed_packages=()
+
+for pkg_json in packages/*/package.json; do
+  private=$(jq -r '.private // false' "$pkg_json")
+  name=$(jq -r '.name' "$pkg_json")
+
+  if [ "$private" = "true" ]; then
+    echo "SKIP (private): $name"
+    skipped_private=$((skipped_private + 1))
+    continue
+  fi
+
+  echo -n "Checking $name ... "
+
+  trust_output=$(npm trust list --json "$name" 2>/dev/null || true)
+
+  if echo "$trust_output" | jq -e 'select(.type == "github")' >/dev/null 2>&1; then
+    echo "already configured"
+    already_configured=$((already_configured + 1))
+    continue
+  fi
+
+  echo -n "configuring ... "
+
+  if npm trust github "$name" --file "$WORKFLOW_FILE" --repo "$REPO" --yes 2>&1; then
+    echo "done"
+    newly_configured=$((newly_configured + 1))
+  else
+    echo "FAILED"
+    failed=$((failed + 1))
+    failed_packages+=("$name")
+  fi
+
+  sleep 2
+done
+
+echo ""
+echo "=== Summary ==="
+echo "Already configured: $already_configured"
+echo "Newly configured:   $newly_configured"
+echo "Skipped (private):  $skipped_private"
+echo "Failed:             $failed"
+
+if [ ${#failed_packages[@]} -gt 0 ]; then
+  echo ""
+  echo "Failed packages:"
+  for pkg in "${failed_packages[@]}"; do
+    echo "  - $pkg"
+  done
+fi


### PR DESCRIPTION
Add setup-npm-trust.sh to automate configuring npm trusted publishing via OIDC for all public packages in the monorepo. Add check-npm-publish-status.sh to verify all packages have their current version published to npm.