### PR TITLE
fx: getImageSource used wrong function signature on expo

### DIFF
--- a/packages/common/src/dynamicLoading/dynamic-loading-setting.ts
+++ b/packages/common/src/dynamicLoading/dynamic-loading-setting.ts
@@ -18,6 +18,28 @@ type ExpoFontLoaderModule = {
   loadAsync: (fontFamilyAlias: string, asset: LoadAsyncAsset) => Promise<void>;
 };
 
+// RenderToImageResult needs to be usable as the `source` prop for image,
+// so it must stay compatible with ImageURISource type
+type RenderToImageResult = {
+  /**
+   * The file uri to the image.
+   */
+  uri: string;
+  /**
+   * Image width in dp.
+   */
+  width: number;
+  /**
+   * Image height in dp.
+   */
+  height: number;
+
+  /**
+   * Scale factor of the image. Multiply the dp dimensions by this value to get the dimensions in pixels.
+   * */
+  scale: number;
+};
+
 type ExpoFontUtilsModule = {
   renderToImageAsync: (
     glyph: string,
@@ -26,7 +48,7 @@ type ExpoFontUtilsModule = {
       size?: number;
       color?: number;
     },
-  ) => Promise<string>;
+  ) => Promise<RenderToImageResult>;
 };
 
 declare global {

--- a/packages/common/src/get-image-library.ts
+++ b/packages/common/src/get-image-library.ts
@@ -23,12 +23,14 @@ export const ensureGetImageAvailable = () => {
   if (hasExpoRenderToImage) {
     const { ExpoFontUtils } = globalRef.expo.modules;
     return {
-      getImageForFont: async (fontReference: string, glyph: string, size: number, color: number) =>
-        ExpoFontUtils.renderToImageAsync(glyph, {
+      getImageForFont: async (fontReference: string, glyph: string, size: number, color: number) => {
+        const result = await ExpoFontUtils.renderToImageAsync(glyph, {
           fontFamily: fontReference,
           size,
           color,
-        }),
+        });
+        return result.uri;
+      },
       getImageForFontSync: () => {
         throw new Error(
           'You attempted to call `getImageForFontSync`. Expo dev client with `@react-native-vector-icons/get-image` installed is required for this. Alternatively, call `getImageForFont` or generate the image yourself and bundle it with the app.',
@@ -37,6 +39,6 @@ export const ensureGetImageAvailable = () => {
     };
   }
   throw new Error(
-    'Error in getImageSource / getImageSourceSync: You need to either (1) install `@react-native-vector-icons/get-image` or (2) use Expo SDK 53+ (Expo dev client or Expo Go). Check your setup and rebuild the app.',
+    'Error in getImageSource / getImageSourceSync: You need to either (1) install `@react-native-vector-icons/get-image` or (2) use Expo SDK 54+ (Expo dev client or Expo Go). Check your setup and rebuild the app.',
   );
 };


### PR DESCRIPTION
On expo, `renderToImageAsync` returns not `string` but a more complete object (`RenderToImageResult`).

I updated the signature to reflect this, ensuring there's no breaking change to the api.