### PR TITLE
fix: don't cache errors in image source cache

### DIFF
--- a/packages/common/src/create-icon-set.tsx
+++ b/packages/common/src/create-icon-set.tsx
@@ -3,7 +3,7 @@ import React, { forwardRef, type Ref, useEffect } from 'react';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { Platform, Text, type TextProps, type TextStyle } from 'react-native';
 
-import createIconSourceCache from './create-icon-source-cache';
+import { createIconSourceCache } from './create-icon-source-cache';
 import { DEFAULT_ICON_COLOR, DEFAULT_ICON_SIZE } from './defaults';
 import { dynamicLoader } from './dynamicLoading/dynamic-font-loading';
 import { isDynamicLoadingEnabled } from './dynamicLoading/dynamic-loading-setting';

--- a/packages/common/src/create-icon-source-cache.ts
+++ b/packages/common/src/create-icon-source-cache.ts
@@ -1,29 +1,11 @@
-const TYPE_VALUE = 'value';
-const TYPE_ERROR = 'error';
-
 type ValueData = { uri: string; scale: number };
 
-type Value = { type: typeof TYPE_VALUE; data: ValueData } | { type: typeof TYPE_ERROR; data: Error };
+export function createIconSourceCache() {
+  const cache = new Map<string, ValueData>();
 
-export default function createIconSourceCache() {
-  const cache = new Map<string, Value>();
+  const setValue = (key: string, value: ValueData) => cache.set(key, value);
 
-  const setValue = (key: string, value: ValueData) => cache.set(key, { type: TYPE_VALUE, data: value });
+  const get = (key: string) => cache.get(key);
 
-  const setError = (key: string, error: Error) => cache.set(key, { type: TYPE_ERROR, data: error });
-
-  const get = (key: string) => {
-    const value = cache.get(key);
-    if (!value) {
-      return undefined;
-    }
-
-    const { type, data } = value;
-    if (type === TYPE_ERROR) {
-      throw data;
-    }
-    return data;
-  };
-
-  return { setValue, setError, get };
+  return { setValue, get };
 }

--- a/packages/common/src/get-image-source.ts
+++ b/packages/common/src/get-image-source.ts
@@ -1,7 +1,7 @@
 import type { TextStyle } from 'react-native';
 import { PixelRatio, processColor } from 'react-native';
 
-import type createIconSourceCache from './create-icon-source-cache';
+import type { createIconSourceCache } from './create-icon-source-cache';
 import { DEFAULT_ICON_COLOR, DEFAULT_ICON_SIZE } from './defaults';
 import { ensureGetImageAvailable } from './get-image-library';
 
@@ -19,24 +19,18 @@ export const getImageSourceSync = (
 
   const maybeCachedValue = imageSourceCache.get(cacheKey);
   if (maybeCachedValue !== undefined) {
-    // FIXME: Should this check if it's an error and throw it again?
     return maybeCachedValue;
   }
 
-  try {
-    const imagePath = NativeIconAPI.getImageForFontSync(
-      fontReference,
-      glyph,
-      size,
-      processedColor as number, // FIXME what if a non existent colour was passed in?
-    );
-    const value = { uri: imagePath, scale: PixelRatio.get() };
-    imageSourceCache.setValue(cacheKey, value);
-    return value;
-  } catch (error) {
-    imageSourceCache.setError(cacheKey, error as Error);
-    throw error;
-  }
+  const imagePath = NativeIconAPI.getImageForFontSync(
+    fontReference,
+    glyph,
+    size,
+    processedColor as number, // FIXME what if a non existent colour was passed in?,
+  );
+  const value = { uri: imagePath, scale: PixelRatio.get() };
+  imageSourceCache.setValue(cacheKey, value);
+  return value;
 };
 
 export const getImageSource = async (
@@ -53,22 +47,11 @@ export const getImageSource = async (
 
   const maybeCachedValue = imageSourceCache.get(cacheKey);
   if (maybeCachedValue !== undefined) {
-    // FIXME: Should this check if it's an error and throw it again?
     return maybeCachedValue;
   }
 
-  try {
-    const imagePath = await NativeIconAPI.getImageForFont(
-      fontReference,
-      glyph,
-      size,
-      processedColor as number, // FIXME what if a non existent colour was passed in?
-    );
-    const value = { uri: imagePath, scale: PixelRatio.get() };
-    imageSourceCache.setValue(cacheKey, value);
-    return value;
-  } catch (error) {
-    imageSourceCache.setError(cacheKey, error as Error);
-    throw error;
-  }
+  const imagePath = await NativeIconAPI.getImageForFont(fontReference, glyph, size, processedColor as number);
+  const value = { uri: imagePath, scale: PixelRatio.get() };
+  imageSourceCache.setValue(cacheKey, value);
+  return value;
 };


### PR DESCRIPTION
## Summary
- Remove error caching from `getImageSource` and `getImageSourceSync` — caching errors served no purpose and added unnecessary complexity to the cache
- Simplify `createIconSourceCache` to a plain value cache now that error storage is unused
- Also includes the fix from #1882 (`getImageSourceSync` wrong function signature on Expo) which was not published due to a typo in the commit prefix (`fx:` instead of `fix:`)