### PR TITLE
refactor(android): remove use of deprecated TurboReactPackage

### DIFF
--- a/packages/ant-design/android/src/main/java/VectorIconsAntDesignPackage.kt
+++ b/packages/ant-design/android/src/main/java/VectorIconsAntDesignPackage.kt
@@ -1,11 +1,11 @@
 package com.reactnativevectoricons.ant_design
 
-import com.facebook.react.TurboReactPackage
+import com.facebook.react.BaseReactPackage
 import com.facebook.react.bridge.NativeModule
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.module.model.ReactModuleInfoProvider
 
-class VectorIconsAntDesignPackage : TurboReactPackage() {
+class VectorIconsAntDesignPackage : BaseReactPackage() {
     override fun getModule(
         name: String,
         reactContext: ReactApplicationContext,

--- a/packages/entypo/android/src/main/java/VectorIconsEntypoPackage.kt
+++ b/packages/entypo/android/src/main/java/VectorIconsEntypoPackage.kt
@@ -1,11 +1,11 @@
 package com.reactnativevectoricons.entypo
 
-import com.facebook.react.TurboReactPackage
+import com.facebook.react.BaseReactPackage
 import com.facebook.react.bridge.NativeModule
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.module.model.ReactModuleInfoProvider
 
-class VectorIconsEntypoPackage : TurboReactPackage() {
+class VectorIconsEntypoPackage : BaseReactPackage() {
     override fun getModule(
         name: String,
         reactContext: ReactApplicationContext,

--- a/packages/evil-icons/android/src/main/java/VectorIconsEvilIconsPackage.kt
+++ b/packages/evil-icons/android/src/main/java/VectorIconsEvilIconsPackage.kt
@@ -1,11 +1,11 @@
 package com.reactnativevectoricons.evil_icons
 
-import com.facebook.react.TurboReactPackage
+import com.facebook.react.BaseReactPackage
 import com.facebook.react.bridge.NativeModule
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.module.model.ReactModuleInfoProvider
 
-class VectorIconsEvilIconsPackage : TurboReactPackage() {
+class VectorIconsEvilIconsPackage : BaseReactPackage() {
     override fun getModule(
         name: String,
         reactContext: ReactApplicationContext,

--- a/packages/feather/android/src/main/java/VectorIconsFeatherPackage.kt
+++ b/packages/feather/android/src/main/java/VectorIconsFeatherPackage.kt
@@ -1,11 +1,11 @@
 package com.reactnativevectoricons.feather
 
-import com.facebook.react.TurboReactPackage
+import com.facebook.react.BaseReactPackage
 import com.facebook.react.bridge.NativeModule
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.module.model.ReactModuleInfoProvider
 
-class VectorIconsFeatherPackage : TurboReactPackage() {
+class VectorIconsFeatherPackage : BaseReactPackage() {
     override fun getModule(
         name: String,
         reactContext: ReactApplicationContext,

--- a/packages/fontawesome-free-brands/android/src/main/java/VectorIconsFontAwesomeFreeBrandsPackage.kt
+++ b/packages/fontawesome-free-brands/android/src/main/java/VectorIconsFontAwesomeFreeBrandsPackage.kt
@@ -1,11 +1,11 @@
 package com.reactnativevectoricons.fontawesome_free_brands
 
-import com.facebook.react.TurboReactPackage
+import com.facebook.react.BaseReactPackage
 import com.facebook.react.bridge.NativeModule
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.module.model.ReactModuleInfoProvider
 
-class VectorIconsFontAwesomeFreeBrandsPackage : TurboReactPackage() {
+class VectorIconsFontAwesomeFreeBrandsPackage : BaseReactPackage() {
     override fun getModule(
         name: String,
         reactContext: ReactApplicationContext,

--- a/packages/fontawesome-free-regular/android/src/main/java/VectorIconsFontAwesomeFreeRegularPackage.kt
+++ b/packages/fontawesome-free-regular/android/src/main/java/VectorIconsFontAwesomeFreeRegularPackage.kt
@@ -1,11 +1,11 @@
 package com.reactnativevectoricons.fontawesome_free_regular
 
-import com.facebook.react.TurboReactPackage
+import com.facebook.react.BaseReactPackage
 import com.facebook.react.bridge.NativeModule
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.module.model.ReactModuleInfoProvider
 
-class VectorIconsFontAwesomeFreeRegularPackage : TurboReactPackage() {
+class VectorIconsFontAwesomeFreeRegularPackage : BaseReactPackage() {
     override fun getModule(
         name: String,
         reactContext: ReactApplicationContext,

--- a/packages/fontawesome-free-solid/android/src/main/java/VectorIconsFontAwesomeFreeSolidPackage.kt
+++ b/packages/fontawesome-free-solid/android/src/main/java/VectorIconsFontAwesomeFreeSolidPackage.kt
@@ -1,11 +1,11 @@
 package com.reactnativevectoricons.fontawesome_free_solid
 
-import com.facebook.react.TurboReactPackage
+import com.facebook.react.BaseReactPackage
 import com.facebook.react.bridge.NativeModule
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.module.model.ReactModuleInfoProvider
 
-class VectorIconsFontAwesomeFreeSolidPackage : TurboReactPackage() {
+class VectorIconsFontAwesomeFreeSolidPackage : BaseReactPackage() {
     override fun getModule(
         name: String,
         reactContext: ReactApplicationContext,

--- a/packages/fontawesome-pro-brands/android/src/main/java/VectorIconsFontAwesomeProBrandsPackage.kt
+++ b/packages/fontawesome-pro-brands/android/src/main/java/VectorIconsFontAwesomeProBrandsPackage.kt
@@ -1,11 +1,11 @@
 package com.reactnativevectoricons.fontawesome_pro_brands
 
-import com.facebook.react.TurboReactPackage
+import com.facebook.react.BaseReactPackage
 import com.facebook.react.bridge.NativeModule
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.module.model.ReactModuleInfoProvider
 
-class VectorIconsFontAwesomeProBrandsPackage : TurboReactPackage() {
+class VectorIconsFontAwesomeProBrandsPackage : BaseReactPackage() {
     override fun getModule(
         name: String,
         reactContext: ReactApplicationContext,

--- a/packages/fontawesome-pro-duotone-light/android/src/main/java/VectorIconsFontAwesomeProDuotoneLightPackage.kt
+++ b/packages/fontawesome-pro-duotone-light/android/src/main/java/VectorIconsFontAwesomeProDuotoneLightPackage.kt
@@ -1,11 +1,11 @@
 package com.reactnativevectoricons.fontawesome_pro_duotone_light
 
-import com.facebook.react.TurboReactPackage
+import com.facebook.react.BaseReactPackage
 import com.facebook.react.bridge.NativeModule
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.module.model.ReactModuleInfoProvider
 
-class VectorIconsFontAwesomeProDuotoneLightPackage : TurboReactPackage() {
+class VectorIconsFontAwesomeProDuotoneLightPackage : BaseReactPackage() {
     override fun getModule(
         name: String,
         reactContext: ReactApplicationContext,

--- a/packages/fontawesome-pro-duotone-regular/android/src/main/java/VectorIconsFontAwesomeProDuotoneRegularPackage.kt
+++ b/packages/fontawesome-pro-duotone-regular/android/src/main/java/VectorIconsFontAwesomeProDuotoneRegularPackage.kt
@@ -1,11 +1,11 @@
 package com.reactnativevectoricons.fontawesome_pro_duotone_regular
 
-import com.facebook.react.TurboReactPackage
+import com.facebook.react.BaseReactPackage
 import com.facebook.react.bridge.NativeModule
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.module.model.ReactModuleInfoProvider
 
-class VectorIconsFontAwesomeProDuotoneRegularPackage : TurboReactPackage() {
+class VectorIconsFontAwesomeProDuotoneRegularPackage : BaseReactPackage() {
     override fun getModule(
         name: String,
         reactContext: ReactApplicationContext,

--- a/packages/fontawesome-pro-duotone-solid/android/src/main/java/VectorIconsFontAwesomeProDuotoneSolidPackage.kt
+++ b/packages/fontawesome-pro-duotone-solid/android/src/main/java/VectorIconsFontAwesomeProDuotoneSolidPackage.kt
@@ -1,11 +1,11 @@
 package com.reactnativevectoricons.fontawesome_pro_duotone_solid
 
-import com.facebook.react.TurboReactPackage
+import com.facebook.react.BaseReactPackage
 import com.facebook.react.bridge.NativeModule
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.module.model.ReactModuleInfoProvider
 
-class VectorIconsFontAwesomeProDuotoneSolidPackage : TurboReactPackage() {
+class VectorIconsFontAwesomeProDuotoneSolidPackage : BaseReactPackage() {
     override fun getModule(
         name: String,
         reactContext: ReactApplicationContext,

--- a/packages/fontawesome-pro-duotone-thin/android/src/main/java/VectorIconsFontAwesomeProDuotoneThinPackage.kt
+++ b/packages/fontawesome-pro-duotone-thin/android/src/main/java/VectorIconsFontAwesomeProDuotoneThinPackage.kt
@@ -1,11 +1,11 @@
 package com.reactnativevectoricons.fontawesome_pro_duotone_thin
 
-import com.facebook.react.TurboReactPackage
+import com.facebook.react.BaseReactPackage
 import com.facebook.react.bridge.NativeModule
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.module.model.ReactModuleInfoProvider
 
-class VectorIconsFontAwesomeProDuotoneThinPackage : TurboReactPackage() {
+class VectorIconsFontAwesomeProDuotoneThinPackage : BaseReactPackage() {
     override fun getModule(
         name: String,
         reactContext: ReactApplicationContext,

--- a/packages/fontawesome-pro-light/android/src/main/java/VectorIconsFontAwesomeProLightPackage.kt
+++ b/packages/fontawesome-pro-light/android/src/main/java/VectorIconsFontAwesomeProLightPackage.kt
@@ -1,11 +1,11 @@
 package com.reactnativevectoricons.fontawesome_pro_light
 
-import com.facebook.react.TurboReactPackage
+import com.facebook.react.BaseReactPackage
 import com.facebook.react.bridge.NativeModule
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.module.model.ReactModuleInfoProvider
 
-class VectorIconsFontAwesomeProLightPackage : TurboReactPackage() {
+class VectorIconsFontAwesomeProLightPackage : BaseReactPackage() {
     override fun getModule(
         name: String,
         reactContext: ReactApplicationContext,

--- a/packages/fontawesome-pro-regular/android/src/main/java/VectorIconsFontAwesomeProRegularPackage.kt
+++ b/packages/fontawesome-pro-regular/android/src/main/java/VectorIconsFontAwesomeProRegularPackage.kt
@@ -1,11 +1,11 @@
 package com.reactnativevectoricons.fontawesome_pro_regular
 
-import com.facebook.react.TurboReactPackage
+import com.facebook.react.BaseReactPackage
 import com.facebook.react.bridge.NativeModule
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.module.model.ReactModuleInfoProvider
 
-class VectorIconsFontAwesomeProRegularPackage : TurboReactPackage() {
+class VectorIconsFontAwesomeProRegularPackage : BaseReactPackage() {
     override fun getModule(
         name: String,
         reactContext: ReactApplicationContext,

--- a/packages/fontawesome-pro-sharp-duotone-light/android/src/main/java/VectorIconsFontAwesomeProSharpDuotoneLightPackage.kt
+++ b/packages/fontawesome-pro-sharp-duotone-light/android/src/main/java/VectorIconsFontAwesomeProSharpDuotoneLightPackage.kt
@@ -1,11 +1,11 @@
 package com.reactnativevectoricons.fontawesome_pro_sharp_duotone_light
 
-import com.facebook.react.TurboReactPackage
+import com.facebook.react.BaseReactPackage
 import com.facebook.react.bridge.NativeModule
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.module.model.ReactModuleInfoProvider
 
-class VectorIconsFontAwesomeProSharpDuotoneLightPackage : TurboReactPackage() {
+class VectorIconsFontAwesomeProSharpDuotoneLightPackage : BaseReactPackage() {
     override fun getModule(
         name: String,
         reactContext: ReactApplicationContext,

--- a/packages/fontawesome-pro-sharp-duotone-regular/android/src/main/java/VectorIconsFontAwesomeProSharpDuotoneRegularPackage.kt
+++ b/packages/fontawesome-pro-sharp-duotone-regular/android/src/main/java/VectorIconsFontAwesomeProSharpDuotoneRegularPackage.kt
@@ -1,11 +1,11 @@
 package com.reactnativevectoricons.fontawesome_pro_sharp_duotone_regular
 
-import com.facebook.react.TurboReactPackage
+import com.facebook.react.BaseReactPackage
 import com.facebook.react.bridge.NativeModule
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.module.model.ReactModuleInfoProvider
 
-class VectorIconsFontAwesomeProSharpDuotoneRegularPackage : TurboReactPackage() {
+class VectorIconsFontAwesomeProSharpDuotoneRegularPackage : BaseReactPackage() {
     override fun getModule(
         name: String,
         reactContext: ReactApplicationContext,

--- a/packages/fontawesome-pro-sharp-duotone-solid/android/src/main/java/VectorIconsFontAwesomeProSharpDuotoneSolidPackage.kt
+++ b/packages/fontawesome-pro-sharp-duotone-solid/android/src/main/java/VectorIconsFontAwesomeProSharpDuotoneSolidPackage.kt
@@ -1,11 +1,11 @@
 package com.reactnativevectoricons.fontawesome_pro_sharp_duotone_solid
 
-import com.facebook.react.TurboReactPackage
+import com.facebook.react.BaseReactPackage
 import com.facebook.react.bridge.NativeModule
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.module.model.ReactModuleInfoProvider
 
-class VectorIconsFontAwesomeProSharpDuotoneSolidPackage : TurboReactPackage() {
+class VectorIconsFontAwesomeProSharpDuotoneSolidPackage : BaseReactPackage() {
     override fun getModule(
         name: String,
         reactContext: ReactApplicationContext,

--- a/packages/fontawesome-pro-sharp-duotone-thin/android/src/main/java/VectorIconsFontAwesomeProSharpDuotoneThinPackage.kt
+++ b/packages/fontawesome-pro-sharp-duotone-thin/android/src/main/java/VectorIconsFontAwesomeProSharpDuotoneThinPackage.kt
@@ -1,11 +1,11 @@
 package com.reactnativevectoricons.fontawesome_pro_sharp_duotone_thin
 
-import com.facebook.react.TurboReactPackage
+import com.facebook.react.BaseReactPackage
 import com.facebook.react.bridge.NativeModule
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.module.model.ReactModuleInfoProvider
 
-class VectorIconsFontAwesomeProSharpDuotoneThinPackage : TurboReactPackage() {
+class VectorIconsFontAwesomeProSharpDuotoneThinPackage : BaseReactPackage() {
     override fun getModule(
         name: String,
         reactContext: ReactApplicationContext,

--- a/packages/fontawesome-pro-sharp-light/android/src/main/java/VectorIconsFontAwesomeProSharpLightPackage.kt
+++ b/packages/fontawesome-pro-sharp-light/android/src/main/java/VectorIconsFontAwesomeProSharpLightPackage.kt
@@ -1,11 +1,11 @@
 package com.reactnativevectoricons.fontawesome_pro_sharp_light
 
-import com.facebook.react.TurboReactPackage
+import com.facebook.react.BaseReactPackage
 import com.facebook.react.bridge.NativeModule
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.module.model.ReactModuleInfoProvider
 
-class VectorIconsFontAwesomeProSharpLightPackage : TurboReactPackage() {
+class VectorIconsFontAwesomeProSharpLightPackage : BaseReactPackage() {
     override fun getModule(
         name: String,
         reactContext: ReactApplicationContext,

--- a/packages/fontawesome-pro-sharp-regular/android/src/main/java/VectorIconsFontAwesomeProSharpRegularPackage.kt
+++ b/packages/fontawesome-pro-sharp-regular/android/src/main/java/VectorIconsFontAwesomeProSharpRegularPackage.kt
@@ -1,11 +1,11 @@
 package com.reactnativevectoricons.fontawesome_pro_sharp_regular
 
-import com.facebook.react.TurboReactPackage
+import com.facebook.react.BaseReactPackage
 import com.facebook.react.bridge.NativeModule
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.module.model.ReactModuleInfoProvider
 
-class VectorIconsFontAwesomeProSharpRegularPackage : TurboReactPackage() {
+class VectorIconsFontAwesomeProSharpRegularPackage : BaseReactPackage() {
     override fun getModule(
         name: String,
         reactContext: ReactApplicationContext,

--- a/packages/fontawesome-pro-sharp-solid/android/src/main/java/VectorIconsFontAwesomeProSharpSolidPackage.kt
+++ b/packages/fontawesome-pro-sharp-solid/android/src/main/java/VectorIconsFontAwesomeProSharpSolidPackage.kt
@@ -1,11 +1,11 @@
 package com.reactnativevectoricons.fontawesome_pro_sharp_solid
 
-import com.facebook.react.TurboReactPackage
+import com.facebook.react.BaseReactPackage
 import com.facebook.react.bridge.NativeModule
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.module.model.ReactModuleInfoProvider
 
-class VectorIconsFontAwesomeProSharpSolidPackage : TurboReactPackage() {
+class VectorIconsFontAwesomeProSharpSolidPackage : BaseReactPackage() {
     override fun getModule(
         name: String,
         reactContext: ReactApplicationContext,

--- a/packages/fontawesome-pro-sharp-thin/android/src/main/java/VectorIconsFontAwesomeProSharpThinPackage.kt
+++ b/packages/fontawesome-pro-sharp-thin/android/src/main/java/VectorIconsFontAwesomeProSharpThinPackage.kt
@@ -1,11 +1,11 @@
 package com.reactnativevectoricons.fontawesome_pro_sharp_thin
 
-import com.facebook.react.TurboReactPackage
+import com.facebook.react.BaseReactPackage
 import com.facebook.react.bridge.NativeModule
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.module.model.ReactModuleInfoProvider
 
-class VectorIconsFontAwesomeProSharpThinPackage : TurboReactPackage() {
+class VectorIconsFontAwesomeProSharpThinPackage : BaseReactPackage() {
     override fun getModule(
         name: String,
         reactContext: ReactApplicationContext,

--- a/packages/fontawesome-pro-solid/android/src/main/java/VectorIconsFontAwesomeProSolidPackage.kt
+++ b/packages/fontawesome-pro-solid/android/src/main/java/VectorIconsFontAwesomeProSolidPackage.kt
@@ -1,11 +1,11 @@
 package com.reactnativevectoricons.fontawesome_pro_solid
 
-import com.facebook.react.TurboReactPackage
+import com.facebook.react.BaseReactPackage
 import com.facebook.react.bridge.NativeModule
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.module.model.ReactModuleInfoProvider
 
-class VectorIconsFontAwesomeProSolidPackage : TurboReactPackage() {
+class VectorIconsFontAwesomeProSolidPackage : BaseReactPackage() {
     override fun getModule(
         name: String,
         reactContext: ReactApplicationContext,

--- a/packages/fontawesome-pro-thin/android/src/main/java/VectorIconsFontAwesomeProThinPackage.kt
+++ b/packages/fontawesome-pro-thin/android/src/main/java/VectorIconsFontAwesomeProThinPackage.kt
@@ -1,11 +1,11 @@
 package com.reactnativevectoricons.fontawesome_pro_thin
 
-import com.facebook.react.TurboReactPackage
+import com.facebook.react.BaseReactPackage
 import com.facebook.react.bridge.NativeModule
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.module.model.ReactModuleInfoProvider
 
-class VectorIconsFontAwesomeProThinPackage : TurboReactPackage() {
+class VectorIconsFontAwesomeProThinPackage : BaseReactPackage() {
     override fun getModule(
         name: String,
         reactContext: ReactApplicationContext,

--- a/packages/fontawesome/android/src/main/java/VectorIconsFontAwesomePackage.kt
+++ b/packages/fontawesome/android/src/main/java/VectorIconsFontAwesomePackage.kt
@@ -1,11 +1,11 @@
 package com.reactnativevectoricons.fontawesome
 
-import com.facebook.react.TurboReactPackage
+import com.facebook.react.BaseReactPackage
 import com.facebook.react.bridge.NativeModule
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.module.model.ReactModuleInfoProvider
 
-class VectorIconsFontAwesomePackage : TurboReactPackage() {
+class VectorIconsFontAwesomePackage : BaseReactPackage() {
     override fun getModule(
         name: String,
         reactContext: ReactApplicationContext,

--- a/packages/fontawesome5-pro/android/src/main/java/VectorIconsFontAwesome5ProPackage.kt
+++ b/packages/fontawesome5-pro/android/src/main/java/VectorIconsFontAwesome5ProPackage.kt
@@ -1,11 +1,11 @@
 package com.reactnativevectoricons.fontawesome5_pro
 
-import com.facebook.react.TurboReactPackage
+import com.facebook.react.BaseReactPackage
 import com.facebook.react.bridge.NativeModule
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.module.model.ReactModuleInfoProvider
 
-class VectorIconsFontAwesome5ProPackage : TurboReactPackage() {
+class VectorIconsFontAwesome5ProPackage : BaseReactPackage() {
     override fun getModule(
         name: String,
         reactContext: ReactApplicationContext,

--- a/packages/fontawesome5/android/src/main/java/VectorIconsFontAwesome5Package.kt
+++ b/packages/fontawesome5/android/src/main/java/VectorIconsFontAwesome5Package.kt
@@ -1,11 +1,11 @@
 package com.reactnativevectoricons.fontawesome5
 
-import com.facebook.react.TurboReactPackage
+import com.facebook.react.BaseReactPackage
 import com.facebook.react.bridge.NativeModule
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.module.model.ReactModuleInfoProvider
 
-class VectorIconsFontAwesome5Package : TurboReactPackage() {
+class VectorIconsFontAwesome5Package : BaseReactPackage() {
     override fun getModule(
         name: String,
         reactContext: ReactApplicationContext,

--- a/packages/fontawesome6-pro/android/src/main/java/VectorIconsFontAwesome6ProPackage.kt
+++ b/packages/fontawesome6-pro/android/src/main/java/VectorIconsFontAwesome6ProPackage.kt
@@ -1,11 +1,11 @@
 package com.reactnativevectoricons.fontawesome6_pro
 
-import com.facebook.react.TurboReactPackage
+import com.facebook.react.BaseReactPackage
 import com.facebook.react.bridge.NativeModule
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.module.model.ReactModuleInfoProvider
 
-class VectorIconsFontAwesome6ProPackage : TurboReactPackage() {
+class VectorIconsFontAwesome6ProPackage : BaseReactPackage() {
     override fun getModule(
         name: String,
         reactContext: ReactApplicationContext,

--- a/packages/fontawesome6/android/src/main/java/VectorIconsFontAwesome6Package.kt
+++ b/packages/fontawesome6/android/src/main/java/VectorIconsFontAwesome6Package.kt
@@ -1,11 +1,11 @@
 package com.reactnativevectoricons.fontawesome6
 
-import com.facebook.react.TurboReactPackage
+import com.facebook.react.BaseReactPackage
 import com.facebook.react.bridge.NativeModule
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.module.model.ReactModuleInfoProvider
 
-class VectorIconsFontAwesome6Package : TurboReactPackage() {
+class VectorIconsFontAwesome6Package : BaseReactPackage() {
     override fun getModule(
         name: String,
         reactContext: ReactApplicationContext,

--- a/packages/fontello/android/src/main/java/VectorIconsFontelloPackage.kt
+++ b/packages/fontello/android/src/main/java/VectorIconsFontelloPackage.kt
@@ -1,11 +1,11 @@
 package com.reactnativevectoricons.fontello
 
-import com.facebook.react.TurboReactPackage
+import com.facebook.react.BaseReactPackage
 import com.facebook.react.bridge.NativeModule
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.module.model.ReactModuleInfoProvider
 
-class VectorIconsFontelloPackage : TurboReactPackage() {
+class VectorIconsFontelloPackage : BaseReactPackage() {
     override fun getModule(
         name: String,
         reactContext: ReactApplicationContext,

--- a/packages/fontisto/android/src/main/java/VectorIconsFontistoPackage.kt
+++ b/packages/fontisto/android/src/main/java/VectorIconsFontistoPackage.kt
@@ -1,11 +1,11 @@
 package com.reactnativevectoricons.fontisto
 
-import com.facebook.react.TurboReactPackage
+import com.facebook.react.BaseReactPackage
 import com.facebook.react.bridge.NativeModule
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.module.model.ReactModuleInfoProvider
 
-class VectorIconsFontistoPackage : TurboReactPackage() {
+class VectorIconsFontistoPackage : BaseReactPackage() {
     override fun getModule(
         name: String,
         reactContext: ReactApplicationContext,

--- a/packages/foundation/android/src/main/java/VectorIconsFoundationPackage.kt
+++ b/packages/foundation/android/src/main/java/VectorIconsFoundationPackage.kt
@@ -1,11 +1,11 @@
 package com.reactnativevectoricons.foundation
 
-import com.facebook.react.TurboReactPackage
+import com.facebook.react.BaseReactPackage
 import com.facebook.react.bridge.NativeModule
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.module.model.ReactModuleInfoProvider
 
-class VectorIconsFoundationPackage : TurboReactPackage() {
+class VectorIconsFoundationPackage : BaseReactPackage() {
     override fun getModule(
         name: String,
         reactContext: ReactApplicationContext,

--- a/packages/generator-react-native-vector-icons/src/app/templates/android/src/main/java/Package.kt
+++ b/packages/generator-react-native-vector-icons/src/app/templates/android/src/main/java/Package.kt
@@ -1,11 +1,11 @@
 package com.reactnativevectoricons.<%= androidName %>
 
-import com.facebook.react.TurboReactPackage
+import com.facebook.react.BaseReactPackage
 import com.facebook.react.bridge.NativeModule
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.module.model.ReactModuleInfoProvider
 
-class VectorIcons<%= className %>Package : TurboReactPackage() {
+class VectorIcons<%= className %>Package : BaseReactPackage() {
     override fun getModule(
         name: String,
         reactContext: ReactApplicationContext,

--- a/packages/icomoon/android/src/main/java/VectorIconsIcomoonPackage.kt
+++ b/packages/icomoon/android/src/main/java/VectorIconsIcomoonPackage.kt
@@ -1,11 +1,11 @@
 package com.reactnativevectoricons.icomoon
 
-import com.facebook.react.TurboReactPackage
+import com.facebook.react.BaseReactPackage
 import com.facebook.react.bridge.NativeModule
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.module.model.ReactModuleInfoProvider
 
-class VectorIconsIcomoonPackage : TurboReactPackage() {
+class VectorIconsIcomoonPackage : BaseReactPackage() {
     override fun getModule(
         name: String,
         reactContext: ReactApplicationContext,

--- a/packages/ionicons/android/src/main/java/VectorIconsIoniconsPackage.kt
+++ b/packages/ionicons/android/src/main/java/VectorIconsIoniconsPackage.kt
@@ -1,11 +1,11 @@
 package com.reactnativevectoricons.ionicons
 
-import com.facebook.react.TurboReactPackage
+import com.facebook.react.BaseReactPackage
 import com.facebook.react.bridge.NativeModule
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.module.model.ReactModuleInfoProvider
 
-class VectorIconsIoniconsPackage : TurboReactPackage() {
+class VectorIconsIoniconsPackage : BaseReactPackage() {
     override fun getModule(
         name: String,
         reactContext: ReactApplicationContext,

--- a/packages/lucide/android/src/main/java/VectorIconsLucidePackage.kt
+++ b/packages/lucide/android/src/main/java/VectorIconsLucidePackage.kt
@@ -1,11 +1,11 @@
 package com.reactnativevectoricons.lucide
 
-import com.facebook.react.TurboReactPackage
+import com.facebook.react.BaseReactPackage
 import com.facebook.react.bridge.NativeModule
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.module.model.ReactModuleInfoProvider
 
-class VectorIconsLucidePackage : TurboReactPackage() {
+class VectorIconsLucidePackage : BaseReactPackage() {
     override fun getModule(
         name: String,
         reactContext: ReactApplicationContext,

--- a/packages/material-design-icons/android/src/main/java/VectorIconsMaterialDesignIconsPackage.kt
+++ b/packages/material-design-icons/android/src/main/java/VectorIconsMaterialDesignIconsPackage.kt
@@ -1,11 +1,11 @@
 package com.reactnativevectoricons.material_design_icons
 
-import com.facebook.react.TurboReactPackage
+import com.facebook.react.BaseReactPackage
 import com.facebook.react.bridge.NativeModule
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.module.model.ReactModuleInfoProvider
 
-class VectorIconsMaterialDesignIconsPackage : TurboReactPackage() {
+class VectorIconsMaterialDesignIconsPackage : BaseReactPackage() {
     override fun getModule(
         name: String,
         reactContext: ReactApplicationContext,

--- a/packages/material-icons/android/src/main/java/VectorIconsMaterialIconsPackage.kt
+++ b/packages/material-icons/android/src/main/java/VectorIconsMaterialIconsPackage.kt
@@ -1,11 +1,11 @@
 package com.reactnativevectoricons.material_icons
 
-import com.facebook.react.TurboReactPackage
+import com.facebook.react.BaseReactPackage
 import com.facebook.react.bridge.NativeModule
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.module.model.ReactModuleInfoProvider
 
-class VectorIconsMaterialIconsPackage : TurboReactPackage() {
+class VectorIconsMaterialIconsPackage : BaseReactPackage() {
     override fun getModule(
         name: String,
         reactContext: ReactApplicationContext,

--- a/packages/octicons/android/src/main/java/VectorIconsOcticonsPackage.kt
+++ b/packages/octicons/android/src/main/java/VectorIconsOcticonsPackage.kt
@@ -1,11 +1,11 @@
 package com.reactnativevectoricons.octicons
 
-import com.facebook.react.TurboReactPackage
+import com.facebook.react.BaseReactPackage
 import com.facebook.react.bridge.NativeModule
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.module.model.ReactModuleInfoProvider
 
-class VectorIconsOcticonsPackage : TurboReactPackage() {
+class VectorIconsOcticonsPackage : BaseReactPackage() {
     override fun getModule(
         name: String,
         reactContext: ReactApplicationContext,

--- a/packages/simple-line-icons/android/src/main/java/VectorIconsSimpleLineIconsPackage.kt
+++ b/packages/simple-line-icons/android/src/main/java/VectorIconsSimpleLineIconsPackage.kt
@@ -1,11 +1,11 @@
 package com.reactnativevectoricons.simple_line_icons
 
-import com.facebook.react.TurboReactPackage
+import com.facebook.react.BaseReactPackage
 import com.facebook.react.bridge.NativeModule
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.module.model.ReactModuleInfoProvider
 
-class VectorIconsSimpleLineIconsPackage : TurboReactPackage() {
+class VectorIconsSimpleLineIconsPackage : BaseReactPackage() {
     override fun getModule(
         name: String,
         reactContext: ReactApplicationContext,

--- a/packages/zocial/android/src/main/java/VectorIconsZocialPackage.kt
+++ b/packages/zocial/android/src/main/java/VectorIconsZocialPackage.kt
@@ -1,11 +1,11 @@
 package com.reactnativevectoricons.zocial
 
-import com.facebook.react.TurboReactPackage
+import com.facebook.react.BaseReactPackage
 import com.facebook.react.bridge.NativeModule
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.module.model.ReactModuleInfoProvider
 
-class VectorIconsZocialPackage : TurboReactPackage() {
+class VectorIconsZocialPackage : BaseReactPackage() {
     override fun getModule(
         name: String,
         reactContext: ReactApplicationContext,


### PR DESCRIPTION
`TurboReactPackage` has been deprecated for a long time with the `BaseReactPackage` replacement.

This is not treated as a breaking change because `BaseReactPackage` has been present in RN core for several years.

The CI failure on iOS is intermittent and unrelated.