### PR TITLE
fix: improve expo codemod instructions and development build detection

### DIFF
--- a/packages/codemod/src/checkGitStatus.ts
+++ b/packages/codemod/src/checkGitStatus.ts
@@ -17,8 +17,6 @@ export function checkGitStatus(dir: string): void {
       console.error(status);
       process.exit(1);
     }
-
-    console.log('✅ Git repository is clean');
   } catch {
     // If git rev-parse fails, the directory is not a git repository
     console.log('!  Directory is not a git repository. Proceeding without git status check.');

--- a/packages/codemod/src/expo/index.ts
+++ b/packages/codemod/src/expo/index.ts
@@ -1,37 +1,43 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
 import { run as jscodeshift } from 'jscodeshift/src/Runner';
 import resolveFrom from 'resolve-from';
 
 import { updatePackageJson } from './package-json';
 
-async function shouldUseStaticImports(dir: string): Promise<boolean> {
+function detectDevClient(dir: string): boolean {
   const hasExpoDevClient = resolveFrom.silent(dir, 'expo-dev-client/package.json') != null;
+  const hasAndroidDir = fs.existsSync(path.join(dir, 'android'));
+  const hasIosDir = fs.existsSync(path.join(dir, 'ios'));
+  const hasDevClient = hasExpoDevClient || hasAndroidDir || hasIosDir;
 
-  if (hasExpoDevClient) {
+  if (hasDevClient) {
     console.log(
-      '\nDetected expo-dev-client. Defaulting to /static imports (e.g. @react-native-vector-icons/material-icons/static).',
+      '\n🔧 Detected Expo development build. Defaulting to `/static` imports (e.g. `@react-native-vector-icons/material-icons/static`).',
     );
   } else {
     console.log(
-      '\nNo expo-dev-client detected (assuming Expo Go). Using default imports (e.g. @react-native-vector-icons/material-icons).',
+      '\n🔧 No Expo development build detected (assuming Expo Go). Using default imports (e.g. `@react-native-vector-icons/material-icons`).',
     );
   }
-  return hasExpoDevClient;
+  return hasDevClient;
 }
 
 export async function runExpoMigration(dir: string) {
   const transformPath = require.resolve('./import-transform');
 
   process.chdir(dir);
-  console.log(`Running Expo codemod in directory: ${dir}`);
+  console.log(`🚀 Running Expo codemod in directory: ${path.resolve(dir)}`);
 
-  const useStatic = await shouldUseStaticImports(dir);
+  const hasDevClient = detectDevClient(dir);
 
   await jscodeshift(transformPath, ['.'], {
     verbose: process.env.VERBOSE === 'true' || process.env.VERBOSE === '1',
     extensions: 'js,jsx,ts,tsx',
     parser: 'tsx',
     ignorePattern: '**/node_modules/**',
-    useStatic,
+    useStatic: hasDevClient,
   });
-  await updatePackageJson(dir);
+  await updatePackageJson(dir, hasDevClient);
 }

--- a/packages/codemod/src/expo/package-json.ts
+++ b/packages/codemod/src/expo/package-json.ts
@@ -1,11 +1,11 @@
-import { execSync } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
+import { getVersion } from '../getVersion';
 import { getNewFontImports } from './newFontImports';
 
-export async function updatePackageJson(dir: string) {
+export async function updatePackageJson(dir: string, hasExpoDevClient: boolean) {
   const packageJsonPath = path.join(dir, 'package.json');
 
   if (!fs.existsSync(packageJsonPath)) {
@@ -28,16 +28,27 @@ export async function updatePackageJson(dir: string) {
   }
 
   const newFontImports = getNewFontImports();
+  const versions = await Promise.all(newFontImports.map((pkg) => getVersion(pkg)));
+
+  newFontImports.forEach((pkg, i) => {
+    packageJson.dependencies[pkg] = versions[i];
+  });
 
   fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2) + os.EOL);
 
-  execSync(`npx expo install ${newFontImports.join(' ')}`, {
-    cwd: dir,
-    stdio: 'inherit',
-  });
-
   console.log(
-    `@expo/vector-icons was removed from package.json. As a replacement, the following ${newFontImports.length} packages were added: ${newFontImports.join(', ')}.`,
+    `📦 \`@expo/vector-icons\` was removed from package.json. As a replacement, the following ${newFontImports.length} packages were added: ${newFontImports.join(', ')}.`,
   );
-  console.log('If you need to, you can add @expo/vector-icons back by running `npx expo install @expo/vector-icons`');
+
+  console.log('\n👉 Run `npx expo install` to install the new dependencies.');
+
+  if (hasExpoDevClient) {
+    const pluginsList = newFontImports.map((name) => `    "${name}"`).join(',\n');
+    console.warn(
+      `\n⚠️  ACTION REQUIRED: Because you are using a development build, you have to enable each new package's Expo config plugin so the icon fonts are registered natively.\n` +
+        `Add the following entries to the "plugins" array in your app config (app.json / app.config.js / app.config.ts):\n\n` +
+        `  "plugins": [\n${pluginsList}\n  ]\n\n` +
+        `Then rebuild your development build (\`npx expo prebuild --clean\` followed by \`npx expo run:ios\` / \`npx expo run:android\`, or rebuild via EAS).`,
+    );
+  }
 }

--- a/packages/codemod/src/getVersion.ts
+++ b/packages/codemod/src/getVersion.ts
@@ -1,6 +1,10 @@
 export const getVersion = async (pkg: string) => {
-  const packageJson = await fetch(`https://registry.npmjs.org/${pkg}/latest`).then(
-    (res) => res.json() as unknown as { version: string },
-  );
-  return `^${packageJson.version}`;
+  try {
+    const packageJson = await fetch(`https://registry.npmjs.org/${pkg}/latest`).then(
+      (res) => res.json() as unknown as { version: string },
+    );
+    return `^${packageJson.version}`;
+  } catch {
+    return 'latest';
+  }
 };

--- a/packages/codemod/src/index.ts
+++ b/packages/codemod/src/index.ts
@@ -51,7 +51,7 @@ async function main() {
 
     if (!version) {
       console.error(
-        `Have not found anything to migrate. Do you have "react-native-vector-icons" or "@expo/vector-icons" at ${path.join(dir, 'package.json')}?`,
+        `Have not found anything to migrate. Do you have "react-native-vector-icons" or "@expo/vector-icons" in ${path.join(dir, 'package.json')}?`,
       );
       process.exit(1);
     }


### PR DESCRIPTION
Improve Expo codemod:

- Detect dev builds by checking for `expo-dev-client`, `android/` or `ios/` dirs (matching eas-cli's approach)
- Fetch latest versions from npm registry instead of running `npx expo install` (I think this will work just fine and there might be other manual steps anyway)
- Fall back to `latest` if npm registry version fetch fails
- Remove redundant "Git repository is clean" message (it doesn't serve any purpose)