### PR TITLE
feat: allow icon name type-checking in fontello and icomoon

### DIFF
--- a/apps/icon-explorer/src/CustomFonts.ts
+++ b/apps/icon-explorer/src/CustomFonts.ts
@@ -3,13 +3,13 @@ import createIcoMoonIconSet from '@react-native-vector-icons/icomoon';
 import FontelloConfig from '../rnvi-fonts/fontello/fontello.config.json';
 import IcoMoonConfig from '../rnvi-fonts/icomoon/icomoon.config.json';
 
-export const Fontello = createFontelloIconSet(FontelloConfig);
+export const Fontello = createFontelloIconSet<'home'>(FontelloConfig);
 export const FontelloGlyphs: Record<string, number> = {};
 FontelloConfig.glyphs.forEach((glyph) => {
   FontelloGlyphs[glyph.css] = glyph.code;
 });
 
-export const IcoMoon = createIcoMoonIconSet(IcoMoonConfig);
+export const IcoMoon = createIcoMoonIconSet<'house'>(IcoMoonConfig);
 export const IcoMoonGlyphs: Record<string, number> = {};
 IcoMoonConfig.glyphs.forEach((icon) => {
   icon.extras.name.split(/\s*,\s*/g).forEach((name) => {

--- a/apps/icon-explorer/src/IconList.tsx
+++ b/apps/icon-explorer/src/IconList.tsx
@@ -79,9 +79,9 @@ export const IconList = ({ iconName, iconStyle = undefined }: { iconName: IconNa
       return undefined;
     }
 
-    const searchListner = DeviceEventEmitter.addListener('onSearchIcons', (e) => setFilter(e.query.toLowerCase()));
+    const searchListener = DeviceEventEmitter.addListener('onSearchIcons', (e) => setFilter(e.query.toLowerCase()));
 
-    return searchListner.remove;
+    return searchListener.remove;
   }, []);
 
   const handleSearchChange = (event: TextInputChangeEvent) => setFilter(event.nativeEvent.text.toLowerCase());

--- a/packages/fontello/README.md
+++ b/packages/fontello/README.md
@@ -32,6 +32,19 @@ import fontelloConfig from "./config.json";
 const Icon = createIconSet(fontelloConfig, "Font Family", "FontFamily.ttf");
 ```
 
+### Type-checked icon names
+
+You can pass a union of icon names as a generic parameter to get type-checking and autocomplete on the `name` prop:
+
+```tsx
+import createIconSet from '@react-native-vector-icons/fontello';
+import fontelloConfig from './config.json';
+const Icon = createIconSet<'home' | 'settings' | 'user'>(fontelloConfig);
+
+<Icon name="home" />     // ok
+<Icon name="invalid" />  // type error
+```
+
 ### Expo Config Plugin
 
 This package ships an [Expo config plugin](../../docs/SETUP-EXPO.md) to register the font with iOS. Add it to the `plugins` array in your `app.json` or `app.config.js`:

--- a/packages/fontello/src/index.ts
+++ b/packages/fontello/src/index.ts
@@ -20,22 +20,23 @@ type FontelloConfig = {
   }>;
 };
 
-type FontelloComponent = IconComponent<Record<string, number>>;
-
 // entries are optional because they can be derived from the config
 type Options = Partial<CreateIconSetOptions>;
 
-export default function createIconSetFromFontello(
+export default function createIconSetFromFontello<Names extends string = string>(
   config: FontelloConfig,
   postScriptName?: string,
   fontFileName?: string,
-): FontelloComponent;
-export default function createIconSetFromFontello(config: FontelloConfig, options: Options): FontelloComponent;
-export default function createIconSetFromFontello(
+): IconComponent<Record<Names, number>>;
+export default function createIconSetFromFontello<Names extends string = string>(
+  config: FontelloConfig,
+  options: Options,
+): IconComponent<Record<Names, number>>;
+export default function createIconSetFromFontello<Names extends string = string>(
   config: FontelloConfig,
   postScriptNameOrOptions?: string | Options,
   fontFileNameParam?: string,
-): FontelloComponent {
+): IconComponent<Record<Names, number>> {
   const { postScriptName, fontFileName, fontSource, fontStyle } =
     typeof postScriptNameOrOptions === 'object'
       ? postScriptNameOrOptions
@@ -51,7 +52,7 @@ export default function createIconSetFromFontello(
 
   const fontFamily = postScriptName || config.name || 'fontello';
 
-  return createIconSet(glyphMap, {
+  return createIconSet<Record<Names, number>>(glyphMap as Record<Names, number>, {
     postScriptName: fontFamily,
     fontFileName: fontFileName || `${fontFamily}.ttf`,
     fontSource,

--- a/packages/icomoon/README.md
+++ b/packages/icomoon/README.md
@@ -32,6 +32,19 @@ import icoMoonConfig from "./IcoMoon-Free.json";
 const Icon = createIconSet(icoMoonConfig, "Font Family", "FontFamily.ttf");
 ```
 
+### Type-checked icon names
+
+You can pass a union of icon names as a generic parameter to get type-checking and autocomplete on the `name` prop:
+
+```tsx
+import createIconSet from '@react-native-vector-icons/icomoon';
+import icoMoonConfig from './IcoMoon-Free.json';
+const Icon = createIconSet<'home' | 'settings' | 'user'>(icoMoonConfig);
+
+<Icon name="home" />     // ok
+<Icon name="invalid" />  // type error
+```
+
 ### Expo Config Plugin
 
 This package ships an [Expo config plugin](../../docs/SETUP-EXPO.md) to register the font with iOS. Add it to the `plugins` array in your `app.json` or `app.config.js`:

--- a/packages/icomoon/src/index.ts
+++ b/packages/icomoon/src/index.ts
@@ -41,22 +41,23 @@ type IcoMoonConfig =
       };
     };
 
-type IcoMoonComponent = IconComponent<Record<string, number>>;
-
 // entries are optional because they can be derived from the config
 type Options = Partial<CreateIconSetOptions>;
 
-export default function createIconSetFromIcoMoon(
+export default function createIconSetFromIcoMoon<Names extends string = string>(
   config: IcoMoonConfig,
   postScriptName?: string,
   fontFileName?: string,
-): IcoMoonComponent;
-export default function createIconSetFromIcoMoon(config: IcoMoonConfig, options: Options): IcoMoonComponent;
-export default function createIconSetFromIcoMoon(
+): IconComponent<Record<Names, number>>;
+export default function createIconSetFromIcoMoon<Names extends string = string>(
+  config: IcoMoonConfig,
+  options: Options,
+): IconComponent<Record<Names, number>>;
+export default function createIconSetFromIcoMoon<Names extends string = string>(
   config: IcoMoonConfig,
   postScriptNameOrOptions?: string | Options,
   fontFileNameParam?: string,
-): IcoMoonComponent {
+): IconComponent<Record<Names, number>> {
   const { postScriptName, fontFileName, fontSource, fontStyle } =
     typeof postScriptNameOrOptions === 'object'
       ? postScriptNameOrOptions
@@ -86,7 +87,7 @@ export default function createIconSetFromIcoMoon(
 
   const fontFamily = postScriptName || (config.preferences?.fontPref?.metadata?.fontFamily ?? 'icomoon');
 
-  return createIconSet(glyphMap, {
+  return createIconSet<Record<Names, number>>(glyphMap as Record<Names, number>, {
     postScriptName: fontFamily,
     fontFileName: fontFileName || `${fontFamily}.ttf`,
     fontSource,


### PR DESCRIPTION
The Fontello and IcoMoon helpers wrap `createIconSet` (which is generic over its glyph map) but previously hard-coded the glyph map to `Record<string, number>`. That discarded the caller's type info, so `<Fontello name="..." />` accepted any string with no autocomplete or type-checking.

This adds an optional `Names extends string` generic parameter (defaulting to `string`, so existing callers are unaffected) that callers can pass to opt into typed icon names:

```ts
const Fontello = createFontelloIconSet<'home' | 'user'>(config);
<Fontello name="user" />  // ok
<Fontello name="bad" />   // type error
```

Same for `createIconSetFromIcoMoon`.

The example app (`apps/icon-explorer`) is updated to demonstrate the new API.