### PR TITLE
feat: expand codemod features and docs

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,119 +1,163 @@
-# Major version migration instructions
+# Migration guide
 
-We provide a `codemod` to help migrate your code and settings between major versions.
+We provide a codemod to migrate from `@expo/vector-icons` or the legacy `react-native-vector-icons` single-package setup to the new scoped `@react-native-vector-icons/*` packages. It updates imports, adjusts `package.json`, and depending on the migration path, fixes changed props and cleans up font files — but it does **not** change icon names (see [What the codemod does not do](#what-the-codemod-does-not-do)).
 
 > [!IMPORTANT]
-> Make sure your code is committed to git or backed up before executing the codemod and review all changes before committing them.
+> Make sure your code is committed to git before running the codemod. Review all codemod changes before committing them.
 
 ```sh
-npx @react-native-vector-icons/codemod
+npx @react-native-vector-icons/codemod .
 ```
 
-## Expo projects
+The codemod auto-detects which migration to run based on the dependencies in your `package.json`.
 
-To migrate from `@expo/vector-icons`, run the codemod in your Expo project. If you use `createIconSetFromIcoMoon` or `createIconSetFromFontello`, there may be some manual steps required after running the codemod:
+## What the codemod does not do
+
+The codemod does **not** rename or validate icon names. When you upgrade the underlying icon library (e.g. to a newer version of FontAwesome or MaterialCommunityIcons), some icons may have been renamed or removed upstream.
+
+For example, an icon called `"arrow-right"` in one version may become `"arrow-forward"` or be dropped entirely. The codemod will not catch this — but **TypeScript will**. After running the codemod, check for type errors in your project to find any icon names that are no longer valid.
+
+---
+
+## Migrating from `@expo/vector-icons` (Expo projects)
+
+The codemod rewrites all `@expo/vector-icons` imports to their `@react-native-vector-icons/*` equivalents and updates `package.json`.
+
+It auto-detects whether you're using a development build (has `expo-dev-client`, or `android`/`ios` directories) and chooses the appropriate import style:
+
+- **Development builds**: uses `/static` imports (fonts bundled at build time)
+- **Expo Go**: uses default imports (fonts loaded at runtime)
+
+### Import transforms
+
+**Named (barrel) imports** are split into separate default imports:
+
+```diff
+-import { Ionicons, MaterialIcons } from '@expo/vector-icons';
++import Ionicons from "@react-native-vector-icons/ionicons";
++import MaterialIcons from "@react-native-vector-icons/material-icons";
+```
+
+**Default imports** from a specific family are rewritten:
+
+```diff
+-import Ionicons from '@expo/vector-icons/Ionicons';
++import Ionicons from "@react-native-vector-icons/ionicons";
+```
+
+**Legacy `/build/` imports** are handled too:
+
+```diff
+-import Ionicons from '@expo/vector-icons/build/Ionicons';
++import Ionicons from "@react-native-vector-icons/ionicons";
+```
+
+**`createIconSetFromIcoMoon` and `createIconSetFromFontello`** — both imports and call signatures are rewritten:
 
 ```diff
 -import createIconSetFromFontello from '@expo/vector-icons/createIconSetFromFontello';
 +import createIconSetFromFontello from '@react-native-vector-icons/fontello';
 
--createIconSetFromFontello(fontelloConfig, 'fontello', require('path/to/fontello.ttf'));
+-createIconSetFromFontello(fontelloConfig, 'fontello', require('./fontello.ttf'));
 +createIconSetFromFontello(fontelloConfig, {
-+    fontSource: require('path/to/fontello.ttf')
++  fontSource: require('./fontello.ttf')
 +});
 ```
 
+### `package.json` updates
+
+- Removes `@expo/vector-icons`
+- Adds individual `@react-native-vector-icons/*` packages (only those your code actually imports)
+
+If you're using a development build, the codemod will print instructions for adding Expo config plugins to your app config.
+
+### Local import names are preserved
+
+If you imported a component under a custom name, it stays:
+
+```diff
+-import MyIcons from '@expo/vector-icons/Entypo';
++import MyIcons from "@react-native-vector-icons/entypo";
+
+-import { Entypo as MyIcons } from '@expo/vector-icons';
++import MyIcons from "@react-native-vector-icons/entypo";
+```
+
+---
+
 ## React Native CLI projects
 
-The codemod attempts to execute many of the manual steps listed below. Thoroughly check each section below for any steps that aren't automatically handled.
+## Migrating from `react-native-vector-icons` (v10 and earlier → v11+)
+
+### Import transforms
+
+Rewrites the old single-library-style imports to scoped package imports with `/static`:
+
+```diff
+-import Ionicons from 'react-native-vector-icons/Ionicons';
++import Ionicons from "@react-native-vector-icons/ionicons/static";
+
+-import FontAwesome from 'react-native-vector-icons/FontAwesome';
++import FontAwesome from "@react-native-vector-icons/fontawesome/static";
+
+-import MaterialCommunityIcons from 'react-native-vector-icons/MaterialCommunityIcons';
++import MaterialCommunityIcons from "@react-native-vector-icons/material-design-icons/static";
+```
+
+### FontAwesome style prop transforms
+
+Boolean style props on FontAwesome 5/6 components are converted to the `iconStyle` prop:
+
+```diff
+-<FontAwesome5 name="heart" solid />
++<FontAwesome5 name="heart" iconStyle="solid" />
+
+-<FontAwesome6 name="github" brand />
++<FontAwesome6 name="github" iconStyle="brand" />
+
+-<FontAwesome6Pro name="star" light />
++<FontAwesome6Pro name="star" iconStyle="light" />
+```
+
+All FontAwesome styles are handled: `solid`, `brand`, `light`, `thin`, `duotone`, `sharp`, `sharpSolid`, `sharpLight`.
 
 > [!NOTE]
-> The codemod is a best effort, read through all the manual steps to ensure they have been completed.
+> The codemod matches components named `FontAwesome5`, `FontAwesome6`, `FontAwesome5Pro`, `FontAwesome6Pro`, or `Icon`. If you imported the component under a different name, you'll need to update the style props manually.
 
-## Migration from react-native-vector-icons to @react-native-vector-icons/\* v12.0+
+### `package.json` updates
 
-In v12, the library has been simplified to require very little setup and does not require the explicit installation of `@react-native-vector-icons/common` package.
+- Removes `react-native-vector-icons`
+- Adds `@react-native-vector-icons/common` and individual font packages that your code imports
 
-### package.json
+### Manual steps (not covered by the codemod)
 
-Unless you are using `createIconSet` directly with your own font, remove `@react-native-vector-icons/common` from your `package.json`. If it's not there, go to the next step.
-
-```sh
-npm uninstall @react-native-vector-icons/common
-```
-
-### Move FontAwesome Pro, icomoon and fontello fonts
-
-> [!WARNING]
-> Only FontAwesome Pro fonts are supported by the codemod
-
-These fonts should be in `rnvi-fonts` or a folder you defined in `package.json`
-
-They need to be moved to a subfolder of `rnvi-fonts` with the name of the font package.
-
-- fontawesome5-pro
-- fontawesome6-pro
-- fontello
-- icomoon
-
-### package.json
-
-Remove `react-native-vector-icons` from your dependencies and replace with the fonts you intend to use, e.g. `@react-native-vector-icons/fontisto`.
-
-### imports
-
-Update your import statements to use the new library names
-
-```js
-// Old
-import Fontisto from "react-native-vector-icons";
-
-// New
-import { Fontisto } from "@react-native-vector-icons/fontisto";
-```
-
-### Move to new props for Fontawesome 5 and 6
-
-The FontAwesome 5 and 6 fonts now take an `iconType` prop instead of a style name prop
-
-```jsx
-// Old
-<FontAwesome5 name="house" solid />
-
-// New
-<FontAwesome5 name="house" iconType="solid" />
-```
-
-Note: The codemod assumes you used the naming from the old README for your component e.g. `FontAwesome5` or `Icon`
-If you have imported the component with another name you will need to modify the codemod or make the changes yourself.
-
-### Remove unused fonts from Info.plist
-
-You still need to add fonts in `Info.plist` - but only those which you have installed.
-
-Check the [React Native Setup](./docs/SETUP-REACT-NATIVE.md) instructions for instructions on how to update it with our included script.
-
-### iOS
-
-> [!WARNING]
-> This is not supported by the codemod
-
-If you aren't using any other fonts, remove the `Fonts` folder and any fonts you have added.
-
-Select your project in the navigator, choose your app's target, go to the Build Phases tab, and under Copy Bundle Resources, remove any fonts.
-
-Remove any entries in `react-native.config.js`:
-
-```js
-// react-native.config.js;
-module.exports = {
-  dependencies: {
-    // Remove any entries like this
-    "react-native-vector-icons": {
-      platforms: {
-        ios: null,
+- **iOS Xcode project**: Remove the `Fonts` folder and any vector icon fonts from your target's Copy Bundle Resources build phase
+- **`react-native.config.js`**: Remove any `react-native-vector-icons` entries:
+  ```js
+  // Remove entries like this:
+  module.exports = {
+    dependencies: {
+      "react-native-vector-icons": {
+        platforms: { ios: null },
       },
     },
-  },
-};
-```
+  };
+  ```
+
+---
+
+## Migrating from v11 → v12+
+
+v12 simplifies setup — `@react-native-vector-icons/common` is no longer required as a direct dependency.
+
+### What the codemod does
+
+- Removes `@react-native-vector-icons/common` from `package.json`
+- Moves FontAwesome Pro fonts from `rnvi-fonts/` into package-specific subfolders (e.g. `rnvi-fonts/fontawesome6-pro/`)
+
+### Manual steps
+
+**icomoon and fontello fonts** need to be moved manually into their subfolders:
+
+- `rnvi-fonts/fontello/`
+- `rnvi-fonts/icomoon/`

--- a/packages/codemod/src/11.0/import-transform.ts
+++ b/packages/codemod/src/11.0/import-transform.ts
@@ -18,6 +18,8 @@ const imports: [string, string][] = [
   ['react-native-vector-icons/Octicons', '@react-native-vector-icons/octicons/static'],
   ['react-native-vector-icons/SimpleLineIcons', '@react-native-vector-icons/SimpleLineIcons/static'],
   ['react-native-vector-icons/Zocial', '@react-native-vector-icons/zocial/static'],
+  ['react-native-vector-icons/createIconSetFromIcoMoon', '@react-native-vector-icons/icomoon'],
+  ['react-native-vector-icons/createIconSetFromFontello', '@react-native-vector-icons/fontello'],
 ];
 
 export default (j: JSCodeshift, root: Collection, r: (msg: string) => void) => {

--- a/packages/codemod/src/11.0/transform.ts
+++ b/packages/codemod/src/11.0/transform.ts
@@ -3,6 +3,8 @@ import type { API, FileInfo } from 'jscodeshift';
 import iconStyleTransform from './icon-style-transform';
 import importTransform from './import-transform';
 
+const createIconSetNames = new Set(['createIconSetFromIcoMoon', 'createIconSetFromFontello']);
+
 export default (file: FileInfo, api: API) => {
   const j = api.jscodeshift;
   const r = api.report;
@@ -11,6 +13,25 @@ export default (file: FileInfo, api: API) => {
   // Apply each transform
   importTransform(j, root, r);
   iconStyleTransform(j, root);
+
+  // Transform createIconSetFromFontello/IcoMoon call signatures:
+  // (config, fontName, fontSource) → (config, { fontSource })
+  root.find(j.CallExpression).forEach((callPath) => {
+    if (
+      callPath.node.callee.type === 'Identifier' &&
+      createIconSetNames.has(callPath.node.callee.name) &&
+      callPath.node.arguments.length === 3
+    ) {
+      const config = callPath.node.arguments[0];
+      const fontSource = callPath.node.arguments[2];
+      callPath.node.arguments = [
+        // biome-ignore lint/style/noNonNullAssertion: length === 3 is checked above
+        config!,
+        // biome-ignore lint/suspicious/noExplicitAny: jscodeshift property builder types are too loose
+        j.objectExpression([j.property('init', j.identifier('fontSource'), fontSource as any)]),
+      ];
+    }
+  });
 
   return root.toSource();
 };

--- a/packages/codemod/src/__tests__/11.0-transform.test.ts
+++ b/packages/codemod/src/__tests__/11.0-transform.test.ts
@@ -126,4 +126,35 @@ const App = () => (
     // deps reported
     expect(reported).toHaveLength(2);
   });
+
+  it('transforms createIconSetFromFontello import and call signature', () => {
+    const input = [
+      `import createIconSetFromFontello from 'react-native-vector-icons/createIconSetFromFontello';`,
+      `const Icon = createIconSetFromFontello(config, 'fontello', require('./font.ttf'));`,
+    ].join('\n');
+    const { output, reported } = applyTransform(input);
+    expect(output).toContain('from "@react-native-vector-icons/fontello"');
+    expect(output).toContain("createIconSetFromFontello(config, {\n  fontSource: require('./font.ttf')\n})");
+    expect(reported).toContain('DEP_FOUND: @react-native-vector-icons/fontello');
+  });
+
+  it('transforms createIconSetFromIcoMoon import and call signature', () => {
+    const input = [
+      `import createIconSetFromIcoMoon from 'react-native-vector-icons/createIconSetFromIcoMoon';`,
+      `const Icon = createIconSetFromIcoMoon(config, 'icomoon', require('./font.ttf'));`,
+    ].join('\n');
+    const { output, reported } = applyTransform(input);
+    expect(output).toContain('from "@react-native-vector-icons/icomoon"');
+    expect(output).toContain("createIconSetFromIcoMoon(config, {\n  fontSource: require('./font.ttf')\n})");
+    expect(reported).toContain('DEP_FOUND: @react-native-vector-icons/icomoon');
+  });
+
+  it('does not transform createIconSet calls with 2 arguments', () => {
+    const input = [
+      `import createIconSetFromFontello from 'react-native-vector-icons/createIconSetFromFontello';`,
+      `const Icon = createIconSetFromFontello(config, { fontSource: require('./font.ttf') });`,
+    ].join('\n');
+    const { output } = applyTransform(input);
+    expect(output).not.toContain('fontSource: {\n');
+  });
 });

--- a/packages/codemod/src/__tests__/expo-import-transform.test.ts
+++ b/packages/codemod/src/__tests__/expo-import-transform.test.ts
@@ -71,6 +71,81 @@ describe('expo import-transform', () => {
       const output = applyTransform(input);
       expect(output).toBe('import createIconSetFromFontello from "@react-native-vector-icons/fontello";');
     });
+
+    it('does not append /static to fontello even with useStatic', () => {
+      const input = `import createIconSetFromFontello from '@expo/vector-icons/createIconSetFromFontello';`;
+      const output = applyTransform(input, { useStatic: true });
+      expect(output).toBe('import createIconSetFromFontello from "@react-native-vector-icons/fontello";');
+    });
+
+    it('does not append /static to icomoon even with useStatic', () => {
+      const input = `import createIconSetFromIcoMoon from '@expo/vector-icons/createIconSetFromIcoMoon';`;
+      const output = applyTransform(input, { useStatic: true });
+      expect(output).toBe('import createIconSetFromIcoMoon from "@react-native-vector-icons/icomoon";');
+    });
+  });
+
+  describe('FontAwesome style prop transforms', () => {
+    it('converts boolean style props to iconStyle on FontAwesome5', () => {
+      const input = [
+        `import FontAwesome5 from '@expo/vector-icons/FontAwesome5';`,
+        `const App = () => <FontAwesome5 name="heart" solid />;`,
+      ].join('\n');
+      const output = applyTransform(input);
+      expect(output).toContain('iconStyle="solid"');
+      expect(output).not.toContain(' solid />');
+    });
+
+    it('converts brand prop on FontAwesome6', () => {
+      const input = [
+        `import FontAwesome6 from '@expo/vector-icons/FontAwesome6';`,
+        `const App = () => <FontAwesome6 name="github" brand />;`,
+      ].join('\n');
+      const output = applyTransform(input);
+      expect(output).toContain('iconStyle="brand"');
+    });
+
+    it('does not convert style props on non-FontAwesome components', () => {
+      const input = [
+        `import Ionicons from '@expo/vector-icons/Ionicons';`,
+        `const App = () => <Ionicons name="heart" solid />;`,
+      ].join('\n');
+      const output = applyTransform(input);
+      expect(output).toContain('solid');
+      expect(output).not.toContain('iconStyle');
+    });
+  });
+
+  describe('createIconSet call signature transform', () => {
+    it('transforms createIconSetFromFontello(config, name, source) to (config, { fontSource })', () => {
+      const input = [
+        `import createIconSetFromFontello from '@expo/vector-icons/createIconSetFromFontello';`,
+        `const Icon = createIconSetFromFontello(config, 'fontello', require('./font.ttf'));`,
+      ].join('\n');
+      const output = applyTransform(input);
+      expect(output).toContain('from "@react-native-vector-icons/fontello"');
+      expect(output).toContain("createIconSetFromFontello(config, {\n  fontSource: require('./font.ttf')\n})");
+    });
+
+    it('transforms createIconSetFromIcoMoon call signature', () => {
+      const input = [
+        `import createIconSetFromIcoMoon from '@expo/vector-icons/createIconSetFromIcoMoon';`,
+        `const Icon = createIconSetFromIcoMoon(config, 'icomoon', require('./font.ttf'));`,
+      ].join('\n');
+      const output = applyTransform(input);
+      expect(output).toContain('from "@react-native-vector-icons/icomoon"');
+      expect(output).toContain("createIconSetFromIcoMoon(config, {\n  fontSource: require('./font.ttf')\n})");
+    });
+
+    it('does not transform calls with 2 arguments (already migrated)', () => {
+      const input = [
+        `import createIconSetFromFontello from '@expo/vector-icons/createIconSetFromFontello';`,
+        `const Icon = createIconSetFromFontello(config, { fontSource: require('./font.ttf') });`,
+      ].join('\n');
+      const output = applyTransform(input);
+      expect(output).toContain('fontSource: require');
+      expect(output).not.toContain('fontSource: {\n');
+    });
   });
 
   describe('edge cases', () => {
@@ -82,6 +157,12 @@ describe('expo import-transform', () => {
 
     it('preserves the local import name for default imports', () => {
       const input = `import MyIcons from '@expo/vector-icons/Entypo';`;
+      const output = applyTransform(input);
+      expect(output).toBe('import MyIcons from "@react-native-vector-icons/entypo";');
+    });
+
+    it('preserves aliases in barrel imports', () => {
+      const input = `import { Entypo as MyIcons } from '@expo/vector-icons';`;
       const output = applyTransform(input);
       expect(output).toBe('import MyIcons from "@react-native-vector-icons/entypo";');
     });

--- a/packages/codemod/src/expo/import-transform.ts
+++ b/packages/codemod/src/expo/import-transform.ts
@@ -1,5 +1,6 @@
 import type { API, FileInfo, Options } from 'jscodeshift';
 
+import iconStyleTransform from '../11.0/icon-style-transform';
 import { addNewFontImport } from './newFontImports';
 
 const importsMap: Record<string, string> = {
@@ -32,9 +33,15 @@ export default function transform(fileInfo: FileInfo, api: API, options: Options
   const useStatic = options.useStatic === true;
 
   const newFontImports = new Set<string>();
+  const createIconSetLocalNames = new Set<string>();
+
+  const noStaticPackages = new Set(['@react-native-vector-icons/icomoon', '@react-native-vector-icons/fontello']);
 
   const resolveImportPath = (basePath: string): string => {
-    return useStatic ? `${basePath}/static` : basePath;
+    if (useStatic && !noStaticPackages.has(basePath)) {
+      return `${basePath}/static`;
+    }
+    return basePath;
   };
 
   // Transform import statements from @expo/vector-icons
@@ -49,10 +56,11 @@ export default function transform(fileInfo: FileInfo, api: API, options: Options
         const newImports = specifiers
           .map((spec) => {
             if (spec.type === 'ImportSpecifier') {
-              const fontName = String(spec.imported.name);
+              const importedName = String(spec.imported.name);
+              const localName = String(spec.local?.name ?? importedName);
 
               // Find the correct mapping for this font
-              const oldName = `@expo/vector-icons/${fontName}`;
+              const oldName = `@expo/vector-icons/${importedName}`;
               const newFontPath = importsMap[oldName];
               if (!newFontPath) {
                 throw new Error(`No mapping found for ${oldName}. Migrate this import manually.`);
@@ -60,8 +68,12 @@ export default function transform(fileInfo: FileInfo, api: API, options: Options
 
               newFontImports.add(newFontPath);
 
+              if (oldName.includes('createIconSet')) {
+                createIconSetLocalNames.add(localName);
+              }
+
               return j.importDeclaration(
-                [j.importDefaultSpecifier(j.identifier(fontName))],
+                [j.importDefaultSpecifier(j.identifier(localName))],
                 j.literal(resolveImportPath(newFontPath)),
               );
             }
@@ -90,8 +102,37 @@ export default function transform(fileInfo: FileInfo, api: API, options: Options
       }
       newFontImports.add(newFontPath);
 
+      if (importPath.includes('createIconSet')) {
+        const localName = path.value.specifiers?.[0]?.local?.name;
+        if (localName) {
+          createIconSetLocalNames.add(String(localName));
+        }
+      }
+
       // Replace with new import
       source.value = resolveImportPath(newFontPath);
+    }
+  });
+
+  // Transform FontAwesome boolean style props to iconStyle="..."
+  iconStyleTransform(j, root);
+
+  // Transform createIconSetFromFontello/IcoMoon call signatures:
+  // (config, fontName, fontSource) → (config, { fontSource })
+  root.find(j.CallExpression).forEach((callPath) => {
+    if (
+      callPath.node.callee.type === 'Identifier' &&
+      createIconSetLocalNames.has(callPath.node.callee.name) &&
+      callPath.node.arguments.length === 3
+    ) {
+      const config = callPath.node.arguments[0];
+      const fontSource = callPath.node.arguments[2];
+      callPath.node.arguments = [
+        // biome-ignore lint/style/noNonNullAssertion: length === 3 is checked above
+        config!,
+        // biome-ignore lint/suspicious/noExplicitAny: jscodeshift property builder types are too loose
+        j.objectExpression([j.property('init', j.identifier('fontSource'), fontSource as any)]),
+      ];
     }
   });
 


### PR DESCRIPTION

## Summary

Rewrites MIGRATION.md to clearly document what the codemod does (and doesn't do)
with before/after examples for each migration path, and improves the codemod
itself with several fixes and new features.

### Codemod improvements

- **`createIconSetFromFontello` / `createIconSetFromIcoMoon` support** — both
codemods (Expo and RN CLI) now rewrite imports and transform the call signature
from `(config, fontName, fontSource)` to `(config, { fontSource })`
- **FontAwesome style prop transforms for Expo** — the Expo codemod now converts
boolean style props (`solid`, `brand`, `light`, etc.) to `iconStyle="..."`,
reusing the existing transform from the 11.0 path
- **Barrel import alias preservation** — `import { Entypo as MyIcons } from
'@expo/vector-icons'` now correctly becomes `import MyIcons from "..."` instead of
 losing the alias

### Documentation

- Restructured into three clear sections: Expo projects, React Native CLI
(v10→v11), and v11→v12
- Added "What the codemod does not do" section explaining that icon names are not
validated (TypeScript catches those)
- Added before/after diff examples for transforms

