### PR TITLE
feat: allow user to specify static / dynamic imports with expo codemod

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -23,10 +23,17 @@ For example, an icon called `"arrow-right"` in one version may become `"arrow-fo
 
 The codemod rewrites all `@expo/vector-icons` imports to their `@react-native-vector-icons/*` equivalents and updates `package.json`.
 
-It auto-detects whether you're using a development build (has `expo-dev-client`, or `android`/`ios` directories) and chooses the appropriate import style:
+It auto-detects whether you're using a development build (has `expo-dev-client`, or `android`/`ios` directories) and picks an import style:
 
-- **Development builds**: uses `/static` imports (fonts bundled at build time)
+- **Development builds**: prompts you to confirm `/static` imports (fonts shipped via the native build, excluded from JS bundle — see [Setup guide for Expo Apps](./docs/SETUP-EXPO.md)). Decline to keep default imports.
 - **Expo Go**: uses default imports (fonts loaded at runtime)
+
+To skip the prompt, pass `--static` or `--dynamic`:
+
+```sh
+npx @react-native-vector-icons/codemod . --static
+npx @react-native-vector-icons/codemod . --dynamic
+```
 
 ### Import transforms
 

--- a/packages/codemod/src/expo/index.ts
+++ b/packages/codemod/src/expo/index.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
+import readline from 'node:readline/promises';
 
 import { run as jscodeshift } from 'jscodeshift/src/Runner';
 import resolveFrom from 'resolve-from';
@@ -10,34 +11,62 @@ function detectDevClient(dir: string): boolean {
   const hasExpoDevClient = resolveFrom.silent(dir, 'expo-dev-client/package.json') != null;
   const hasAndroidDir = fs.existsSync(path.join(dir, 'android'));
   const hasIosDir = fs.existsSync(path.join(dir, 'ios'));
-  const hasDevClient = hasExpoDevClient || hasAndroidDir || hasIosDir;
-
-  if (hasDevClient) {
-    console.log(
-      '\n🔧 Detected Expo development build. Defaulting to `/static` imports (e.g. `@react-native-vector-icons/material-icons/static`).',
-    );
-  } else {
-    console.log(
-      '\n🔧 No Expo development build detected (assuming Expo Go). Using default imports (e.g. `@react-native-vector-icons/material-icons`).',
-    );
-  }
-  return hasDevClient;
+  return hasExpoDevClient || hasAndroidDir || hasIosDir;
 }
 
-export async function runExpoMigration(dir: string) {
+async function confirmStaticImports(): Promise<boolean> {
+  if (!process.stdin.isTTY) {
+    console.log('🔧 Non-interactive run, defaulting to `/static` imports. Pass `--dynamic` to override.');
+    return true;
+  }
+
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+  try {
+    const answer = await rl.question(
+      '\nUse `/static` imports for smaller bundle size? Learn more at https://github.com/oblador/react-native-vector-icons/blob/master/docs/SETUP-EXPO.md. [Y/n] ',
+    );
+    const normalized = answer.trim().toLowerCase();
+    return normalized === '' || normalized === 'y' || normalized === 'yes';
+  } finally {
+    rl.close();
+  }
+}
+
+type RunOptions = {
+  useStatic?: boolean;
+};
+
+export async function runExpoMigration(dir: string, { useStatic: useStaticOverride }: RunOptions = {}) {
   const transformPath = require.resolve('./import-transform');
 
   process.chdir(dir);
   console.log(`🚀 Running Expo codemod in directory: ${path.resolve(dir)}`);
 
-  const hasDevClient = detectDevClient(dir);
+  let useStatic: boolean;
+  if (useStaticOverride !== undefined) {
+    useStatic = useStaticOverride;
+  } else {
+    const hasDevClient = detectDevClient(dir);
+    if (hasDevClient) {
+      console.log('\n🔧 Detected Expo development build.');
+      useStatic = await confirmStaticImports();
+    } else {
+      console.log('\n🔧 No Expo development build detected (assuming Expo Go).');
+      useStatic = false;
+    }
+  }
+
+  console.log(`🔧 Using ${useStatic ? '`/static`' : 'default'} imports.`);
 
   await jscodeshift(transformPath, ['.'], {
     verbose: process.env.VERBOSE === 'true' || process.env.VERBOSE === '1',
     extensions: 'js,jsx,ts,tsx',
     parser: 'tsx',
     ignorePattern: '**/node_modules/**',
-    useStatic: hasDevClient,
+    useStatic,
   });
-  await updatePackageJson(dir, hasDevClient);
+  await updatePackageJson(dir, useStatic);
 }

--- a/packages/codemod/src/index.ts
+++ b/packages/codemod/src/index.ts
@@ -8,8 +8,22 @@ import { checkGitStatus } from './checkGitStatus';
 import { runExpoMigration } from './expo';
 import { readPackageDeps } from './readPackageDeps';
 
+function parseArgs(argv: string[]): { dir: string | undefined; useStatic: boolean | undefined } {
+  let useStatic: boolean | undefined;
+  const positionals: string[] = [];
+  for (const arg of argv) {
+    if (arg === '--static') useStatic = true;
+    else if (arg === '--dynamic') useStatic = false;
+    else if (arg.startsWith('--')) {
+      console.error(`Unknown flag: ${arg}`);
+      process.exit(1);
+    } else positionals.push(arg);
+  }
+  return { dir: positionals[0], useStatic };
+}
+
 async function main() {
-  const dir = process.argv[2];
+  const { dir, useStatic } = parseArgs(process.argv.slice(2));
   if (!dir) {
     console.error('Specify a directory in which to run the codemod');
     process.exit(1);
@@ -29,7 +43,7 @@ async function main() {
   const expoVectorIcons = dependencies['@expo/vector-icons'];
 
   if (expoVectorIcons) {
-    await runExpoMigration(dir);
+    await runExpoMigration(dir, { useStatic });
   } else {
     console.log('Running codemod in', dir);
     if (dependencies['react-native-vector-icons']) {
@@ -64,7 +78,7 @@ async function main() {
   NOTE: You may need to run again to upgrade to the next version.
   NOTE: You may need to run 'npm install' to install new dependencies.
   
-  Check https://github.com/react-native-vector-icons/react-native-vector-icons/blob/master/MIGRATION.md for any manual steps
+  Check https://github.com/oblador/react-native-vector-icons/blob/master/MIGRATION.md for any manual steps
   `);
   }
 }

--- a/packages/codemod/src/index.ts
+++ b/packages/codemod/src/index.ts
@@ -8,7 +8,7 @@ import { checkGitStatus } from './checkGitStatus';
 import { runExpoMigration } from './expo';
 import { readPackageDeps } from './readPackageDeps';
 
-function parseArgs(argv: string[]): { dir: string | undefined; useStatic: boolean | undefined } {
+function parseArgs(argv: string[]): { dir: string; useStatic: boolean | undefined } {
   let useStatic: boolean | undefined;
   const positionals: string[] = [];
   for (const arg of argv) {
@@ -19,15 +19,11 @@ function parseArgs(argv: string[]): { dir: string | undefined; useStatic: boolea
       process.exit(1);
     } else positionals.push(arg);
   }
-  return { dir: positionals[0], useStatic };
+  return { dir: positionals[0] ?? process.cwd(), useStatic };
 }
 
 async function main() {
   const { dir, useStatic } = parseArgs(process.argv.slice(2));
-  if (!dir) {
-    console.error('Specify a directory in which to run the codemod');
-    process.exit(1);
-  }
 
   checkGitStatus(dir);
 


### PR DESCRIPTION
the expo codemod would automatically decide whether to use regular or `/static` imports, now it gives user a choice.

Also, providing project path is now not required (defaults to process.cwd())
