### PR TITLE
fix(codemod): check project path exists early

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -6,8 +6,10 @@ We provide a codemod to migrate from `@expo/vector-icons` or the legacy `react-n
 > Make sure your code is committed to git before running the codemod. Review all codemod changes before committing them.
 
 ```sh
-npx @react-native-vector-icons/codemod .
+npx @react-native-vector-icons/codemod
 ```
+
+By default the codemod runs in the current directory; pass a path to target a different one (e.g. `npx @react-native-vector-icons/codemod ./apps/mobile`).
 
 The codemod auto-detects which migration to run based on the dependencies in your `package.json`.
 
@@ -31,8 +33,8 @@ It auto-detects whether you're using a development build (has `expo-dev-client`,
 To skip the prompt, pass `--static` or `--dynamic`:
 
 ```sh
-npx @react-native-vector-icons/codemod . --static
-npx @react-native-vector-icons/codemod . --dynamic
+npx @react-native-vector-icons/codemod --static
+npx @react-native-vector-icons/codemod --dynamic
 ```
 
 ### Import transforms

--- a/packages/codemod/src/expo/index.ts
+++ b/packages/codemod/src/expo/index.ts
@@ -42,8 +42,7 @@ type RunOptions = {
 export async function runExpoMigration(dir: string, { useStatic: useStaticOverride }: RunOptions = {}) {
   const transformPath = require.resolve('./import-transform');
 
-  process.chdir(dir);
-  console.log(`🚀 Running Expo codemod in directory: ${path.resolve(dir)}`);
+  console.log(`🚀 Running Expo codemod in directory: ${dir}`);
 
   let useStatic: boolean;
   if (useStaticOverride !== undefined) {

--- a/packages/codemod/src/index.ts
+++ b/packages/codemod/src/index.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+import fs from 'node:fs';
 import path from 'node:path';
 
 import semver from 'semver';
@@ -23,7 +24,15 @@ function parseArgs(argv: string[]): { dir: string; useStatic: boolean | undefine
 }
 
 async function main() {
-  const { dir, useStatic } = parseArgs(process.argv.slice(2));
+  const { dir: dirArg, useStatic } = parseArgs(process.argv.slice(2));
+  const dir = path.resolve(dirArg);
+
+  if (!fs.existsSync(dir) || !fs.statSync(dir).isDirectory()) {
+    console.error(`Directory does not exist: ${dir}`);
+    process.exit(1);
+  }
+
+  process.chdir(dir);
 
   checkGitStatus(dir);
 


### PR DESCRIPTION
We previously documented running with `npx @react-native-vector-icons/codemod .` but passing a custom path wouldn't actually work.

I changed it to recommending `npx @react-native-vector-icons/codemod` but if people want to use custom path, they can.