### PR TITLE
docs: document FontAwesome Pro font filenames

### DIFF
--- a/packages/fontawesome5-pro/README.md
+++ b/packages/fontawesome5-pro/README.md
@@ -15,6 +15,19 @@ setting it when executing the command: `npx fa-upgrade5 [destination]` and setti
 If the shell script does not work you can install the Pro version manually.
 All you really need to do is adding the Pro fonts to the `rnvi-fonts/fontawesome5-pro` directory.
 
+The font files must use the names expected by this package. This is especially
+important on Android, where fonts are resolved by filename. The `fa-upgrade5`
+script performs this rename automatically. If you copy the fonts manually, use
+these filenames:
+
+| FontAwesome file | RNVI filename |
+| ---------------- | ------------- |
+| `fa-brands-400.ttf` | `FontAwesome5_Pro_Brands.ttf` |
+| `fa-duotone-900.ttf` | `FontAwesome5_Pro_Duotone.ttf` |
+| `fa-light-300.ttf` | `FontAwesome5_Pro_Light.ttf` |
+| `fa-regular-400.ttf` | `FontAwesome5_Pro_Regular.ttf` |
+| `fa-solid-900.ttf` | `FontAwesome5_Pro_Solid.ttf` |
+
 ## Usage
 
 Using the standard icons works just like the standard icons in this library.

--- a/packages/fontawesome6-pro/README.md
+++ b/packages/fontawesome6-pro/README.md
@@ -15,6 +15,24 @@ setting it when executing the command: `npx fa-upgrade6 [destination]` and setti
 If the shell script does not work you can install the Pro version manually.
 All you really need to do is adding the Pro fonts to the `rnvi-fonts/fontawesome6-pro` directory.
 
+The font files must use the names expected by this package. This is especially
+important on Android, where fonts are resolved by filename. The `fa-upgrade6`
+script performs this rename automatically. If you copy the fonts manually, use
+these filenames:
+
+| FontAwesome file | RNVI filename |
+| ---------------- | ------------- |
+| `fa-brands-400.ttf` | `FontAwesome6_Pro_Brands.ttf` |
+| `fa-duotone-900.ttf` | `FontAwesome6_Pro_Duotone.ttf` |
+| `fa-light-300.ttf` | `FontAwesome6_Pro_Light.ttf` |
+| `fa-regular-400.ttf` | `FontAwesome6_Pro_Regular.ttf` |
+| `fa-sharp-light-300.ttf` | `FontAwesome6_Pro_Sharp_Light.ttf` |
+| `fa-sharp-regular-400.ttf` | `FontAwesome6_Pro_Sharp_Regular.ttf` |
+| `fa-sharp-solid-900.ttf` | `FontAwesome6_Pro_Sharp_Solid.ttf` |
+| `fa-sharp-thin-100.ttf` | `FontAwesome6_Pro_Sharp_Thin.ttf` |
+| `fa-solid-900.ttf` | `FontAwesome6_Pro_Solid.ttf` |
+| `fa-thin-100.ttf` | `FontAwesome6_Pro_Thin.ttf` |
+
 ## Usage
 
 Using the standard icons works just like the standard icons in this library.


### PR DESCRIPTION
## Summary

- document the required FontAwesome 5 Pro font filenames for manual setup
- document the required FontAwesome 6 Pro font filenames for manual setup
- clarify that the `fa-upgrade5` and `fa-upgrade6` scripts perform these renames automatically, while manual copies must use the RNVI filenames

Closes #1888.

## Why

The FontAwesome Pro packages expect specific font filenames, and Android resolves fonts by filename. Users who copy the Pro fonts manually from the FontAwesome package can otherwise keep the upstream names and see missing icons on Android. The README now lists the same filename mappings used by the upgrade scripts.

## Test plan

- `pnpm install`
- `pnpm run lint:biome`
- `pnpm run lint:knip` (also run by the pre-commit hook)
- `git diff --check`

This is a documentation-only change, so no runtime tests were added.